### PR TITLE
Add constructor for `StratifiedSample` and rename abstract type

### DIFF
--- a/src/Survey.jl
+++ b/src/Survey.jl
@@ -22,14 +22,15 @@ include("svyplot.jl")
 include("dimnames.jl")
 include("svyboxplot.jl")
 
-export SurveyDesign, SimpleRandomSample
-export svydesign, svyby, svyglm
 export load_data
+export AbstractSurveyDesign, SimpleRandomSample, StratifiedSample
+export svydesign
+export svyby, svyglm
+export dim, colnames, dimnames
 export svymean, svytotal, svyquantile
 export @formula
-export svyhist, sturges, freedman_diaconis
 export svyplot
-export dim, colnames, dimnames
+export svyhist, sturges, freedman_diaconis
 export svyboxplot
 export
     #families

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -24,6 +24,7 @@ struct SimpleRandomSample <: AbstractSurveyDesign
 
     function SimpleRandomSample(data::DataFrame; weights = ones(nrow(data)), probs = 1 ./ weights)
         # add frequency weights, probability weights and sample size columns
+        # TODO: make lines 28 & 29 use a helper function?
         data[!, :weights] = weights
         data[!, :probs] = probs
         # TODO: change `sampsize` and `popsize`
@@ -35,6 +36,7 @@ struct SimpleRandomSample <: AbstractSurveyDesign
 end
 
 # `show` method for printing information about a `SimpleRandomSample` after construction
+# TODO: change `show` to 3 argument method
 function Base.show(io::IO, design::SimpleRandomSample)
     printstyled("Simple Random Sample:\n")
     printstyled("data: "; bold = true)

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -1,8 +1,17 @@
+# Helper function for nice printing
+function print_short(x::AbstractVector)
+    if length(x) < 3
+        print(x)
+    else
+        print( x[1], ", ", x[2], ", ", x[3], " ...", " (length = ", length(x), ")")
+    end
+end
+
 """
 Supertype for every survey design type: `SimpleRandomSample`, `ClusterSample`
 and `StratifiedSample`.
 """
-abstract type SurveyDesign end
+abstract type AbstractSurveyDesign end
 
 """
 A `SimpleRandomSample` object contains survey design information needed to
@@ -10,30 +19,91 @@ analyse surveys sampled by simple random sampling.
 TODO: documentation about user making a copy
 TODO: add fpc
 """
-struct SimpleRandomSample <: SurveyDesign
+struct SimpleRandomSample <: AbstractSurveyDesign
     data::DataFrame
+
     function SimpleRandomSample(data::DataFrame; weights = ones(nrow(data)), probs = 1 ./ weights)
         # add frequency weights, probability weights and sample size columns
         data[!, :weights] = weights
         data[!, :probs] = probs
+        # TODO: change `sampsize` and `popsize`
+        data[!, :popsize] = repeat([nrow(data)], nrow(data))
         data[!, :sampsize] = repeat([nrow(data)], nrow(data))
 
         new(data)
     end
 end
 
+# `show` method for printing information about a `SimpleRandomSample` after construction
+function Base.show(io::IO, design::SimpleRandomSample)
+    printstyled("Simple Random Sample:\n")
+    printstyled("data: "; bold = true)
+    print(size(design.data)[1], "x", size(design.data)[2], " DataFrame")
+    printstyled("\nprobs: "; bold = true)
+    print_short(design.data.probs)
+    # TODO: change fpc
+    printstyled("\nfpc: "; bold = true)
+    print("\n    popsize: ")
+    print_short(design.data.popsize)
+    print("\n    sampsize: ")
+    print_short(design.data.sampsize)
+end
+
 """
 A `StratifiedSample` object holds information necessary for surveys sampled by
 stratification.
 """
-struct StratifiedSample <: SurveyDesign
+struct StratifiedSample <: AbstractSurveyDesign
     data::DataFrame
+    function StratifiedSample(data::DataFrame, strata::AbstractVector; weights = ones(nrow(data)), probs = 1 ./ weights)
+        # add frequency weights, probability weights and sample size columns
+        data[!, :weights] = weights
+        data[!, :probs] = probs
+        # TODO: change `sampsize` and `popsize`
+        data[!, :popsize] = repeat([nrow(data)], nrow(data))
+        data[!, :sampsize] = repeat([nrow(data)], nrow(data))
+        data[!, :strata] = strata
+
+        new(data)
+    end
+end
+
+# `show` method for printing information about a `StratifiedSample` after construction
+function Base.show(io::IO, design::StratifiedSample)
+    printstyled("Stratified Sample:\n")
+    printstyled("data: "; bold = true)
+    print(size(design.data)[1], "x", size(design.data)[2], " DataFrame")
+    printstyled("\nprobs: "; bold = true)
+    print_short(design.data.probs)
+    printstyled("\nstrata: "; bold = true)
+    print_short(design.data.strata)
+    # TODO: change fpc
+    printstyled("\nfpc: "; bold = true)
+    print("\n    popsize: ")
+    print_short(design.data.popsize)
+    print("\n    sampsize: ")
+    print_short(design.data.sampsize)
 end
 
 """
 A `ClusterSample` object holds information necessary for surveys sampled by
 clustering.
 """
-struct ClusterSample <: SurveyDesign
+struct ClusterSample <: AbstractSurveyDesign
     data::DataFrame
+end
+
+# `show` method for printing information about a `ClusterSample` after construction
+function Base.show(io::IO, design::ClusterSample)
+    printstyled("Simple Random Sample:\n")
+    printstyled("data: "; bold = true)
+    print(size(design.data)[1], "x", size(design.data)[2], " DataFrame")
+    printstyled("\nprobs: "; bold = true)
+    print_short(design.data.probs)
+    # TODO: change fpc
+    printstyled("\nfpc: "; bold = true)
+    print("\n    popsize: ")
+    print_short(design.data.popsize)
+    print("\n    sampsize: ")
+    print_short(design.data.sampsize)
 end

--- a/src/dimnames.jl
+++ b/src/dimnames.jl
@@ -10,10 +10,10 @@ julia> apisrs = load_data("apisrs");
 julia> srs = SimpleRandomSample(apisrs);
 
 julia> dim(srs)
-(200, 43)
+(200, 44)
 ```
 """
-dim(design::SurveyDesign) = size(design.data)
+dim(design::AbstractSurveyDesign) = size(design.data)
 
 """
 Method for `svydesign` object.
@@ -43,7 +43,7 @@ julia> apisrs = load_data("apisrs");
 julia> srs = SimpleRandomSample(apisrs);
 
 julia> colnames(srs)
-43-element Vector{String}:
+44-element Vector{String}:
  "Column1"
  "cds"
  "stype"
@@ -55,7 +55,6 @@ julia> colnames(srs)
  "cname"
  "cnum"
  ⋮
- "full"
  "emer"
  "enroll"
  "api.stu"
@@ -63,10 +62,11 @@ julia> colnames(srs)
  "fpc"
  "weights"
  "probs"
+ "popsize"
  "sampsize"
 ```
 """
-colnames(design::SurveyDesign) = names(design.data)
+colnames(design::AbstractSurveyDesign) = names(design.data)
 
 """
 Method for `svydesign` objects.
@@ -118,10 +118,10 @@ julia> srs = SimpleRandomSample(apisrs);
 julia> dimnames(srs)
 2-element Vector{Vector{String}}:
  ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"  …  "191", "192", "193", "194", "195", "196", "197", "198", "199", "200"]
- ["Column1", "cds", "stype", "name", "sname", "snum", "dname", "dnum", "cname", "cnum"  …  "avg.ed", "full", "emer", "enroll", "api.stu", "pw", "fpc", "weights", "probs", "sampsize"]
+ ["Column1", "cds", "stype", "name", "sname", "snum", "dname", "dnum", "cname", "cnum"  …  "full", "emer", "enroll", "api.stu", "pw", "fpc", "weights", "probs", "popsize", "sampsize"]
 ```
 """
-dimnames(design::SurveyDesign) = [string.(1:size(design.data, 1)), names(design.data)]
+dimnames(design::AbstractSurveyDesign) = [string.(1:size(design.data, 1)), names(design.data)]
 
 """
 Method for `svydesign` objects.

--- a/src/svyboxplot.jl
+++ b/src/svyboxplot.jl
@@ -21,7 +21,7 @@ julia> bp = svyboxplot(srs, :stype, :enroll; weights = :pw)
 
 ![](./assets/boxplot.png)
 """
-function svyboxplot(design::SurveyDesign, x::Symbol, y::Symbol; kwargs...)
+function svyboxplot(design::AbstractSurveyDesign, x::Symbol, y::Symbol; kwargs...)
 	map = mapping(x, y; kwargs...)
 	data = AlgebraOfGraphics.data(design.data)
 

--- a/src/svyby.jl
+++ b/src/svyby.jl
@@ -32,7 +32,7 @@ julia> svyby(:api00, :cname, srs, svytotal)
                  23 rows omitted
 ```
 """
-function svyby(formula::Symbol, by, design::SurveyDesign, func::Function, params = [])
+function svyby(formula::Symbol, by, design::AbstractSurveyDesign, func::Function, params = [])
     gdf = groupby(design.data, by)
     return combine(gdf, [formula, :probs, :sampsize] => ((a, b, c) -> func(a, b, c, params...)) => AsTable)
 end

--- a/src/svydesign.jl
+++ b/src/svydesign.jl
@@ -1,11 +1,11 @@
-# Helper function for nice printing
-function print_short(x)
-    if length(x) < 3
-        print(x)
-    else
-        print( x[1], ", ", x[2], ", ", x[3], " ...", " (length = ", length(x), ")")
-    end
-end
+# # Helper function for nice printing
+# function print_short(x)
+#     if length(x) < 3
+#         print(x)
+#     else
+#         print( x[1], ", ", x[2], ", ", x[3], " ...", " (length = ", length(x), ")")
+#     end
+# end
 
 """
 The `svydesign` object combines a data frame and all the survey design information needed to analyse it.
@@ -106,19 +106,19 @@ function Base.show(io::IO, design::svydesign)
     printstyled("Survey Design:\n")
     printstyled("variables: "; bold = true)
     print(size(design.variables)[1], "x", size(design.variables)[2], " DataFrame")
-        printstyled("\nid: "; bold = true)
-        print(design.id)
-        printstyled("\nstrata: "; bold = true)
-        print_short(design.variables.strata)
-        printstyled("\nprobs: "; bold = true)
-        print_short(design.variables.probs)
-        printstyled("\nfpc: "; bold = true)
-        print("\n    popsize: ")
-        print_short(design.variables.popsize)
-        print("\n    sampsize: ")
-        print_short(design.variables.sampsize)
-        printstyled("\nnest: "; bold = true)
-        print(design.nest)
-        printstyled("\ncheck_strat: "; bold = true)
-        print(design.check_strat)
+    printstyled("\nid: "; bold = true)
+    print(design.id)
+    printstyled("\nstrata: "; bold = true)
+    print_short(design.variables.strata)
+    printstyled("\nprobs: "; bold = true)
+    print_short(design.variables.probs)
+    printstyled("\nfpc: "; bold = true)
+    print("\n    popsize: ")
+    print_short(design.variables.popsize)
+    print("\n    sampsize: ")
+    print_short(design.variables.sampsize)
+    printstyled("\nnest: "; bold = true)
+    print(design.nest)
+    printstyled("\ncheck_strat: "; bold = true)
+    print(design.check_strat)
 end

--- a/src/svyhist.jl
+++ b/src/svyhist.jl
@@ -56,7 +56,7 @@ julia> sturges(srs, :enroll)
 9
 ```
 """
-sturges(design::SurveyDesign, var::Symbol) = sturges(design.data, var)
+sturges(design::AbstractSurveyDesign, var::Symbol) = sturges(design.data, var)
 
 """
     sturges(design::svydesign, var::Symbol)
@@ -120,7 +120,7 @@ julia> freedman_diaconis(srs, :enroll)
 18
 ```
 """
-freedman_diaconis(design::SurveyDesign, var::Symbol) = freedman_diaconis(design.data[!, var])
+freedman_diaconis(design::AbstractSurveyDesign, var::Symbol) = freedman_diaconis(design.data[!, var])
 
 """
     freedman_diaconis(design::svydesign, var::Symbol)
@@ -180,7 +180,7 @@ julia> dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :
 julia> h_old = svyhist(dstrat, :enroll)
 ```
 """
-function svyhist(design::SurveyDesign, var::Symbol,
+function svyhist(design::AbstractSurveyDesign, var::Symbol,
 				 bins::Union{Integer, AbstractVector} = freedman_diaconis(design, var);
 				 normalization = :density,
 				 kwargs...
@@ -189,7 +189,7 @@ function svyhist(design::SurveyDesign, var::Symbol,
 	data(design.data) * mapping(var, weights = :weights) * hist |> draw
 end
 
-function svyhist(design::SurveyDesign, var::Symbol,
+function svyhist(design::AbstractSurveyDesign, var::Symbol,
 				 bins::Function;
 				 kwargs...
     			)

--- a/src/svymean.jl
+++ b/src/svymean.jl
@@ -33,22 +33,22 @@ function svymean(var, design::SimpleRandomSample)
     return DataFrame(mean = mean(x, weights(w)), SE = SE(x, w, ss))
 end
 
-# TODO
-# function svymean(var, design::StratifiedSample)
-#     # popsize correction isn't implemented yet
-#     ss = maximum(design.data.sampsize)
-#     w = design.data.probs
-#     x = design.data[!, var]
-#     strata = groupby(design.data.strata)
-#     function SE(x, w, ss)
-#         f = sqrt(1 - 1 / length(x) + 1 / ss)
-#         x1 = sum(w .* (x .- sum(w .* x) / sum(w)).^2) / sum(w)
-#         sd = sqrt(x1 / (length(x) - 1))
-#         return f * sd
-#     end
+function svymean(var, design::StratifiedSample)
+    # popsize correction isn't implemented yet
+    ss = maximum(design.data.sampsize)
+    w = design.data.probs
+    x = design.data[!, var]
+    strata = design.data.strata
+    # TODO: modify SE to account for stratification
+    function SE(x, w, ss)
+        f = sqrt(1 - 1 / length(x) + 1 / ss)
+        x1 = sum(w .* (x .- sum(w .* x) / sum(w)).^2) / sum(w)
+        sd = sqrt(x1 / (length(x) - 1))
+        return f * sd
+    end
 
-#     return DataFrame(mean = mean(x, weights(w)), SE = SE(x, w, ss))
-# end
+    return DataFrame(mean = mean(x, weights(w)), SE = SE(x, w, ss))
+end
 
 """
 Method for designs of type `svydesign`.

--- a/src/svyplot.jl
+++ b/src/svyplot.jl
@@ -20,7 +20,7 @@ julia> s = svyplot(srs, :api99, :api00)
 # TODO: change the plot image and example
 ![](./assets/scatter.png)
 """
-function svyplot(design::SurveyDesign, x::Symbol, y::Symbol; kwargs...)
+function svyplot(design::AbstractSurveyDesign, x::Symbol, y::Symbol; kwargs...)
     data(design.data) * mapping(x, y, markersize = :weights) * visual(Scatter, marker = '￮') |> draw
 end
 

--- a/src/svyquantile.jl
+++ b/src/svyquantile.jl
@@ -17,7 +17,17 @@ julia> svyquantile(:enroll, srs, 0.5)
 ```
 """
 # TODO: modify for SimpleRandomSample
-function svyquantile(var, design::SurveyDesign, q)
+function svyquantile(var, design::SimpleRandomSample, q)
+    x = design.data[!, var]
+    w = design.data.probs
+    df = DataFrame(tmp = quantile(Float32.(x), weights(w), q))
+    rename!(df, :tmp => Symbol(string(q) .* "th percentile"))
+
+    return df
+end
+
+# TODO: modify for StratifiedSample
+function svyquantile(var, design::StratifiedSample, q)
     x = design.data[!, var]
     w = design.data.probs
     df = DataFrame(tmp = quantile(Float32.(x), weights(w), q))

--- a/src/svytotal.jl
+++ b/src/svytotal.jl
@@ -36,6 +36,26 @@ function svytotal(var, design::SimpleRandomSample)
     DataFrame(total = wsum(Float32.(x), weights(1 ./ wts)), SE = SE(x, wts));
 end
 
+# TODO: standard error
+function svytotal(var, design::StratifiedSample)
+    wts = design.data.probs;  # probability weights
+    x = design.data[!, var];  # column for which the total is calculated
+    strata = design.data.strata
+    # standard error of total - SHOULD BE AN EXTERNAL FUNCTION
+    # change SE to account for stratification
+    function SE(x, w)
+        # remove the warning once the function is fixed
+        # DON'T FORGET TO REMOVE FROM DOCTEST
+        @warn "this is the standard error of the mean"
+        var = sum(w .* (x .- sum(w .* x) / sum(w)).^2) / sum(w)
+        sd = sqrt(var / (length(x) - 1))
+        return sd
+    end
+
+    # return the weighted sum and standard error as a data frame
+    DataFrame(total = wsum(Float32.(x), weights(1 ./ wts)), SE = SE(x, wts));
+end
+
 """
 The `svytotal` function can also be used with a `svydesign` object.
 """

--- a/test/SurveyDesign.jl
+++ b/test/SurveyDesign.jl
@@ -9,11 +9,11 @@
     # THIS NEEDS TO BE CHANGED WHEN `sampsize` IS UPDATED
     @test srs.data.sampsize[1] == size(apisrs_original, 1)
 
-    srs_freq = SimpleRandomSample(apisrs; weights = repeat([0.3], size(apisrs_original, 1)))
+    srs_freq = SimpleRandomSample(apisrs; weights = fill(0.3, nrow(apisrs_original)))
     @test srs_freq.data.weights[1] == 0.3
     @test srs_freq.data.weights == 1 ./ srs_freq.data.probs
 
-    srs_prob = SimpleRandomSample(apisrs; probs = repeat([0.3], size(apisrs_original, 1)))
+    srs_prob = SimpleRandomSample(apisrs; probs = fill(0.3, nrow(apisrs_original)))
     @test srs_prob.data.probs[1] == 0.3
     @test srs_prob.data.weights == ones(size(apisrs_original, 1))
 

--- a/test/SurveyDesign.jl
+++ b/test/SurveyDesign.jl
@@ -1,18 +1,27 @@
 @testset "SurveyDesign.jl" begin
     # SimpleRandomSample tests
-    apisrs = load_data("apisrs")
+    apisrs_original = load_data("apisrs")
+    apisrs = copy(apisrs_original)
 
     srs = SimpleRandomSample(apisrs)
-    @test srs.data.weights == ones(size(apisrs, 1))
+    @test srs.data.weights == ones(size(apisrs_original, 1))
     @test srs.data.weights == srs.data.probs
     # THIS NEEDS TO BE CHANGED WHEN `sampsize` IS UPDATED
-    @test srs.data.sampsize[1] == size(apisrs, 1)
+    @test srs.data.sampsize[1] == size(apisrs_original, 1)
 
-    srs_freq = SimpleRandomSample(apisrs; weights = repeat([0.3], size(apisrs, 1)))
+    srs_freq = SimpleRandomSample(apisrs; weights = repeat([0.3], size(apisrs_original, 1)))
     @test srs_freq.data.weights[1] == 0.3
     @test srs_freq.data.weights == 1 ./ srs_freq.data.probs
 
-    srs_prob = SimpleRandomSample(apisrs; probs = repeat([0.3], size(apisrs, 1)))
+    srs_prob = SimpleRandomSample(apisrs; probs = repeat([0.3], size(apisrs_original, 1)))
     @test srs_prob.data.probs[1] == 0.3
-    @test srs_prob.data.weights == ones(size(apisrs, 1))
+    @test srs_prob.data.weights == ones(size(apisrs_original, 1))
+
+
+    # StratifiedSample tests
+    apistrat = load_data("apistrat")
+    apistrat_copy = copy(apistrat)
+
+    strat = StratifiedSample(apistrat_copy, apistrat_copy.stype)
+    @test strat.data.strata == apistrat.stype
 end

--- a/test/dimnames.jl
+++ b/test/dimnames.jl
@@ -1,7 +1,6 @@
 @testset "dimnames.jl" begin
     # Simple random sampling tests
     apisrs = load_data("apisrs")
-
     # make a copy to not modify the original dataset
     apisrs_copy = copy(apisrs)
     srs_new = SimpleRandomSample(apisrs_copy)
@@ -9,28 +8,36 @@
     apisrs_copy = copy(apisrs)
     srs_old = svydesign(id = :1, data = apisrs)
     # `dim`
-	@test dim(srs_new)[1] == dim(srs_old)[1]
-	@test dim(srs_new)[2] == 43
-	@test dim(srs_old)[2] == 45
+    @test dim(srs_new)[1] == dim(srs_old)[1]
+    @test dim(srs_new)[2] == 44
+    @test dim(srs_old)[2] == 45
     # `colnames`
-	@test length(colnames(srs_new)) == dim(srs_new)[2]
-	@test length(colnames(srs_old)) == dim(srs_old)[2]
+    @test length(colnames(srs_new)) == dim(srs_new)[2]
+    @test length(colnames(srs_old)) == dim(srs_old)[2]
     # `dimnames`
-	@test length(dimnames(srs_new)[1]) == parse(Int, last(dimnames(srs_new)[1]))
-	@test dimnames(srs_new)[2] == colnames(srs_new)
-	@test length(dimnames(srs_old)[1]) == parse(Int, last(dimnames(srs_old)[1]))
-	@test dimnames(srs_old)[2] == colnames(srs_old)
+    @test length(dimnames(srs_new)[1]) == parse(Int, last(dimnames(srs_new)[1]))
+    @test dimnames(srs_new)[2] == colnames(srs_new)
+    @test length(dimnames(srs_old)[1]) == parse(Int, last(dimnames(srs_old)[1]))
+    @test dimnames(srs_old)[2] == colnames(srs_old)
 
     # Stratified sampling tests
-	apistrat = load_data("apistrat")
-
-	dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc)
+    apistrat = load_data("apistrat")
+    # make a copy to not modify the original dataset
+    apistrat_copy = copy(apistrat)
+    strat_new = StratifiedSample(apistrat_copy, apistrat_copy.stype)
+    # make a new copy to use for the old design
+    apistrat_copy = copy(apistrat)
+    strat_old = svydesign(id = :1, data = apistrat_copy, strata = :stype)
     # `dim`
-	@test dim(dstrat)[1] == 200
-	@test dim(dstrat)[2] == size(dstrat.variables, 2)
+    @test dim(strat_new)[1] == dim(strat_old)[1]
+    @test dim(strat_new)[2] == 45
+    @test dim(strat_old)[2] == 45
     # `colnames`
-	@test length(colnames(dstrat)) == dim(dstrat)[2]
+    @test length(colnames(strat_new)) == dim(strat_new)[2]
+    @test length(colnames(strat_old)) == dim(strat_old)[2]
     # `dimnames`
-	@test length(dimnames(dstrat)[1]) == parse(Int, last(dimnames(dstrat)[1]))
-	@test dimnames(dstrat)[2] == colnames(dstrat)
+    @test length(dimnames(strat_new)[1]) == parse(Int, last(dimnames(strat_new)[1]))
+    @test dimnames(strat_new)[2] == colnames(strat_new)
+    @test length(dimnames(strat_old)[1]) == parse(Int, last(dimnames(strat_old)[1]))
+    @test dimnames(strat_old)[2] == colnames(strat_old)
 end

--- a/test/svyboxplot.jl
+++ b/test/svyboxplot.jl
@@ -1,4 +1,4 @@
-@testset "svyplot.jl" begin
+@testset "svyboxplot.jl" begin
     # StratifiedSample
     apisrs = load_data("apisrs")
     srs = SimpleRandomSample(apisrs)
@@ -9,9 +9,9 @@
 
     # StratifiedSample
     apistrat = load_data("apistrat")
-    dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc)
-    bp = svyboxplot(dstrat, :stype, :enroll; weights = :pw)
+    strat = StratifiedSample(apistrat, apistrat.stype)
+    bp = svyboxplot(strat, :stype, :enroll; weights = :pw)
 
-    @test bp.grid[1].entries[1].positional[2] == dstrat.variables[!, :enroll]
-    @test bp.grid[1].entries[1].named[:weights] == dstrat.variables[!, :pw]
+    @test bp.grid[1].entries[1].positional[2] == strat.data[!, :enroll]
+    @test bp.grid[1].entries[1].named[:weights] == strat.data[!, :pw]
 end

--- a/test/svyby.jl
+++ b/test/svyby.jl
@@ -25,4 +25,33 @@
     @test srs_by_cname_prob1[srs_by_cname_prob1.cname .== "Los Angeles", :][!, 2][1] ≈ 644.0
     srs_by_cname_prob2 = svyby(:api00, :cname, srs_prob, svyquantile, 0.25)
     @test srs_by_cname_prob2[srs_by_cname_prob2.cname .== "Los Angeles", :][!, 2][1] ≈ 540.0
+
+
+    # StratifiedSample tests
+    apistrat = load_data("apistrat")
+    strat = StratifiedSample(apistrat, apistrat.stype)
+    # `svyby` with `svytotal`
+    strat_by_cname1 = svyby(:api00, :cname, strat, svytotal)
+    @test strat_by_cname1.cname == unique(apistrat.cname)
+    @test strat_by_cname1[strat_by_cname1.cname .== "Los Angeles", :].total ==  [25283.0]
+    # `svyby` with `svymean`
+    strat_by_cname2 = svyby(:api00, :cname, strat, svymean)
+    @test strat_by_cname2[strat_by_cname2.cname .== "Los Angeles", :].mean[1] ≈ 616.6585365853658
+
+    apistrat = load_data("apistrat")
+    strat_freq = StratifiedSample(apistrat, apistrat.stype; weights = repeat([0.3], size(apistrat, 1)))
+    # `svyby` with `svytotal`
+    strat_by_cname_freq1 = svyby(:api00, :cname, strat_freq, svytotal)
+    @test strat_by_cname_freq1.total ≈ strat_by_cname1.total .* 0.3
+    # `svyby` with `svymean`
+    strat_by_cname_freq2  = svyby(:api00, :cname, strat_freq, svymean)
+    @test strat_by_cname_freq2.mean ≈ strat_by_cname2.mean
+
+    apistrat = load_data("apistrat")
+    strat_prob = StratifiedSample(apistrat, apistrat.stype; probs = repeat([0.3], size(apistrat, 1)))
+    # `svyby` with `svyquantile`
+    strat_by_cname_prob1 = svyby(:api00, :cname, strat_prob, svyquantile, 0.5)
+    @test strat_by_cname_prob1[strat_by_cname_prob1.cname .== "Los Angeles", :][!, 2][1] ≈ 588.0
+    strat_by_cname_prob2 = svyby(:api00, :cname, strat_prob, svyquantile, 0.25)
+    @test strat_by_cname_prob2[strat_by_cname_prob2.cname .== "Los Angeles", :][!, 2][1] ≈ 510.0
 end

--- a/test/svyhist.jl
+++ b/test/svyhist.jl
@@ -21,16 +21,26 @@
     # StratifiedSample
     apistrat = load_data("apistrat")
     dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc)
+    apistrat = load_data("apistrat")
+    strat = StratifiedSample(apistrat, apistrat.stype)
 
+    h = svyhist(strat, :enroll)
+    @test h.grid[1].entries[1].positional[2] |> length == 16
     h = svyhist(dstrat, :enroll)
     @test h.grid[1].entries[1].positional[2] |> length == 16
 
+    h = svyhist(strat, :enroll, 9)
+    @test h.grid[1].entries[1].positional[2] |> length == 7
     h = svyhist(dstrat, :enroll, 9)
     @test h.grid[1].entries[1].positional[2] |> length == 7
 
+    h = svyhist(strat, :enroll, Survey.sturges)
+    @test h.grid[1].entries[1].positional[2] |> length == 7
     h = svyhist(dstrat, :enroll, Survey.sturges)
     @test h.grid[1].entries[1].positional[2] |> length == 7
 
+    h = svyhist(strat, :enroll, [0, 1000, 2000, 3000])
+    @test h.grid[1].entries[1].positional[2] |> length == 3
     h = svyhist(dstrat, :enroll, [0, 1000, 2000, 3000])
     @test h.grid[1].entries[1].positional[2] |> length == 3
 end

--- a/test/svymean.jl
+++ b/test/svymean.jl
@@ -7,4 +7,14 @@
     mean_new = svymean(:api00, srs_new)
     mean_old = svymean(:api00, srs_old)
     @test mean_new == mean_old
+
+
+    # StratifiedSample tests
+    apistrat = load_data("apistrat")
+
+    strat_new = SimpleRandomSample(apistrat)
+    strat_old = svydesign(id = :1, data = apistrat, strata = :stype)
+    mean_new = svymean(:api00, strat_new)
+    mean_old = svymean(:api00, strat_old)
+    @test mean_new == mean_old
 end

--- a/test/svyplot.jl
+++ b/test/svyplot.jl
@@ -10,10 +10,15 @@
 
     # StratifiedSample
     apistrat = load_data("apistrat")
+    strat = StratifiedSample(apistrat, apistrat.stype; weights = apistrat.pw)
     dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc)
-    s_strat = svyplot(dstrat, :api99, :api00)
+    s_strat_new = svyplot(strat, :api99, :api00)
+    s_strat_old = svyplot(dstrat, :api99, :api00)
 
-    @test s_strat.grid[1].entries[1].named[:markersize] == dstrat.variables.weights
-    @test s_strat.grid[1].entries[1].positional[1] == dstrat.variables.api99
-    @test s_strat.grid[1].entries[1].positional[2] == dstrat.variables.api00
+    @test s_strat_new.grid[1].entries[1].named[:markersize] == strat.data.weights
+    @test s_strat_new.grid[1].entries[1].positional[1] == strat.data.api99
+    @test s_strat_new.grid[1].entries[1].positional[2] == strat.data.api00
+    @test s_strat_old.grid[1].entries[1].named[:markersize] == dstrat.variables.weights
+    @test s_strat_old.grid[1].entries[1].positional[1] == dstrat.variables.api99
+    @test s_strat_old.grid[1].entries[1].positional[2] == dstrat.variables.api00
 end

--- a/test/svyquantile.jl
+++ b/test/svyquantile.jl
@@ -12,4 +12,18 @@
     q_025_new = svyquantile(:api00, srs_new, 0.25)
     q_025_old = svyquantile(:api00, srs_old, 0.25)
     @test q_025_new == q_025_old
+
+    # StratifiedSample tests
+    apistrat = load_data("apistrat")
+
+    strat_new = StratifiedSample(apistrat, apistrat.stype)
+    strat_old = svydesign(id = :1, data = apistrat, strata = :stype)
+    # 0.5th percentile
+    q_05_new = svyquantile(:api00, strat_new, 0.5)
+    q_05_old = svyquantile(:api00, strat_old, 0.5)
+    @test q_05_new == q_05_old
+    # 0.25th percentile
+    q_025_new = svyquantile(:api00, strat_new, 0.25)
+    q_025_old = svyquantile(:api00, strat_old, 0.25)
+    @test q_025_new == q_025_old
 end

--- a/test/svytotal.jl
+++ b/test/svytotal.jl
@@ -7,4 +7,13 @@
     tot_new = svytotal(:api00, srs_new)
     tot_old = svytotal(:api00, srs_old)
     @test tot_new.total == tot_old.total
+
+    # StratifiedSample tests
+    apistrat = load_data("apistrat")
+
+    strat_new = StratifiedSample(apistrat, apistrat.stype)
+    strat_old = svydesign(id = :1, data = apistrat, strata = :stype)
+    tot_new = svytotal(:api00, strat_new)
+    tot_old = svytotal(:api00, strat_old)
+    @test tot_new.total == tot_old.total
 end


### PR DESCRIPTION
I added the constructor for `StratifiedSample`, along with functionality for this type. Some things still need to be added or changed, like `fpc`/`sampsize` and `popsize` (see the discussion [here](https://github.com/xKDR/Survey.jl/pull/41#issuecomment-1225505137)). There are TODO comments where I considered changes still need to be done.

Also I added the pretty printing that we had for the old design.