### PR TITLE
Make CI workflow run on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-    push:
-        branches:
-            - main
-    pull_request:
-        branches:
-            - main
+on: [push, pull_request]
     # can add tags if needed
 
 jobs:


### PR DESCRIPTION
Change `on` tags to make CI tests run on all branches for pushes and PRs.