### PR TITLE
Reduce Documenter warnings and errors

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ makedocs(;
         "Comparison with R" => "R_comparison.md",
         "Performance" => "performance.md",
     ],
+    checkdocs=:exports,
 )
 
 deploydocs(;

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,4 +38,8 @@ svyhist(design::AbstractSurveyDesign, var::Symbol,
 				 kwargs...
     			)
 svyboxplot(design::AbstractSurveyDesign, x::Symbol, y::Symbol; kwargs...)
+svydesign
+svyquantile
+sturges
+freedman_diaconis
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,32 +14,33 @@ At [xKDR](https://xkdr.org/) we processed millions of records from household sur
 
 ```@index
 Module = [Survey]
+Order = [:type, :function]
 Private = false
 ```
 
 ## API
 ```@docs
-load_data
 AbstractSurveyDesign
 SimpleRandomSample
 StratifiedSample
 ClusterSample
-dim(design::AbstractSurveyDesign)
-colnames(design::AbstractSurveyDesign)
-dimnames(design::AbstractSurveyDesign)
+svydesign
+svyglm
+load_data
 svymean(x::Symbol, design::SimpleRandomSample)
 svytotal(x::Symbol, design::SimpleRandomSample)
+svyquantile
 svyby
-svyglm
+colnames(design::AbstractSurveyDesign)
+dim(design::AbstractSurveyDesign)
+dimnames(design::AbstractSurveyDesign)
 svyplot(design::AbstractSurveyDesign, x::Symbol, y::Symbol; kwargs...)
+svyboxplot(design::AbstractSurveyDesign, x::Symbol, y::Symbol; kwargs...)
 svyhist(design::AbstractSurveyDesign, var::Symbol,
 				 bins::Union{Integer, AbstractVector} = freedman_diaconis(design, var);
 				 normalization = :density,
 				 kwargs...
     			)
-svyboxplot(design::AbstractSurveyDesign, x::Symbol, y::Symbol; kwargs...)
-svydesign
-svyquantile
-sturges
 freedman_diaconis
+sturges
 ```

--- a/src/dimnames.jl
+++ b/src/dimnames.jl
@@ -13,19 +13,6 @@ julia> dim(srs)
 ```
 """
 dim(design::AbstractSurveyDesign) = size(design.data)
-
-"""
-Method for `svydesign`.
-
-```jldoctest
-julia> apistrat = load_data("apistrat");
-
-julia> dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc);
-
-julia> dim(dstrat)
-(200, 45)
-```
-"""
 dim(design::svydesign) = size(design.variables)
 
 """
@@ -63,39 +50,6 @@ julia> colnames(srs)
 ```
 """
 colnames(design::AbstractSurveyDesign) = names(design.data)
-
-"""
-Method for `svydesign`.
-
-```jldoctest
-julia> apistrat = load_data("apistrat");
-
-julia> dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc);
-
-julia> colnames(dstrat)
-45-element Vector{String}:
- "Column1"
- "cds"
- "stype"
- "name"
- "sname"
- "snum"
- "dname"
- "dnum"
- "cname"
- "cnum"
- ⋮
- "enroll"
- "api.stu"
- "pw"
- "fpc"
- "probs"
- "weights"
- "popsize"
- "sampsize"
- "strata"
-```
-"""
 colnames(design::svydesign) = names(design.variables)
 
 """
@@ -115,19 +69,4 @@ julia> dimnames(srs)
 ```
 """
 dimnames(design::AbstractSurveyDesign) = [string.(1:size(design.data, 1)), names(design.data)]
-
-"""
-Method for `svydesign`.
-
-```jldoctest
-julia> apistrat = load_data("apistrat");
-
-julia> dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc);
-
-julia> dimnames(dstrat)
-2-element Vector{Vector{String}}:
- ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"  …  "191", "192", "193", "194", "195", "196", "197", "198", "199", "200"]
- ["Column1", "cds", "stype", "name", "sname", "snum", "dname", "dnum", "cname", "cnum"  …  "emer", "enroll", "api.stu", "pw", "fpc", "probs", "weights", "popsize", "sampsize", "strata"]
-```
-"""
 dimnames(design::svydesign) = [string.(1:size(design.variables, 1)), names(design.variables)]

--- a/src/svyboxplot.jl
+++ b/src/svyboxplot.jl
@@ -24,9 +24,6 @@ function svyboxplot(design::AbstractSurveyDesign, x::Symbol, y::Symbol; kwargs..
 	data * visual(BoxPlot) * map |> draw
 end
 
-"""
-Method for `svydesign`.
-"""
 function svyboxplot(design::svydesign, x::Symbol, y::Symbol; kwargs...)
     # TODO: change function, make it a wrapper
 	map = mapping(x, y; kwargs...)

--- a/src/svyhist.jl
+++ b/src/svyhist.jl
@@ -1,50 +1,12 @@
-"""
-    sturges(v)
-
-Calculate the number of bins to use in a histogram using the Sturges rule.
-
-# Examples
-```jldoctest
-julia> sturges(10)
-5
-
-julia> sturges([10, 20, 30, 40, 50])
-4
-```
-"""
 sturges(n::Integer) = ceil(Int, log2(n)) + 1
 sturges(vec::AbstractVector) = ceil(Int, log2(length(vec))) + 1
-
-"""
-    sturges(df::DataFrame, var::Symbol)
-
-Calculate the number of bins for a `DataFrame` variable.
-
-# Examples
-```jldoctest
-julia> using DataFrames
-
-julia> df = DataFrame((a=[1, 2, 3, 4, 5], b=[10, 20, 30, 40, 50]))
-5×2 DataFrame
- Row │ a      b
-     │ Int64  Int64
-─────┼──────────────
-   1 │     1     10
-   2 │     2     20
-   3 │     3     30
-   4 │     4     40
-   5 │     5     50
-
-julia> sturges(df, :b)
-4
-```
-"""
 sturges(df::DataFrame, var::Symbol) = ceil(Int, log2(size(df[!, var], 1))) + 1
+sturges(design::svydesign, var::Symbol) = sturges(design.variables, var)
 
 """
     sturges(design::SurveyDesign, var::Symbol)
 
-Calculate the number of bins for a `SurveyDesign`.
+Calculate the number of bins to use in a histogram using the Sturges rule.
 
 # Examples
 ```jldoctest
@@ -58,57 +20,14 @@ julia> sturges(srs, :enroll)
 """
 sturges(design::AbstractSurveyDesign, var::Symbol) = sturges(design.data, var)
 
-"""
-    sturges(design::svydesign, var::Symbol)
-
-Calculate the number of bins for a survey design variable.
-
-# Examples
-```jldoctest
-julia> apistrat = load_data("apistrat");
-
-julia> dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc);
-
-julia> sturges(dstrat, :enroll)
-9
-```
-"""
-sturges(design::svydesign, var::Symbol) = sturges(design.variables, var)
-
-"""
-	freedman_diaconis(v::AbstractVector)
-
-Calculate the number of bins to use in a histogram using the Freedman-Diaconis rule.
-
-# Examples
-```jldoctest
-julia> freedman_diaconis([10, 20, 30, 40, 50])
-2
-```
-"""
 freedman_diaconis(v::AbstractVector) = round(Int, length(v)^(1 / 3) * (maximum(v) - minimum(v)) / (2 * iqr(v)))
-
-"""
-	freedman_diaconis(df::DataFrame, var::Symbol)
-
-Calculate the number of bins for a `DataFrame` variable.
-
-# Examples
-```jldoctest
-julia> using DataFrames
-
-julia> df = DataFrame((a=[1, 2, 3, 4, 5], b=[10, 20, 30, 40, 50]));
-
-julia> freedman_diaconis(df, :b)
-2
-```
-"""
 freedman_diaconis(df::DataFrame, var::Symbol) = freedman_diaconis(df[!, var])
+freedman_diaconis(design::svydesign, var::Symbol) = freedman_diaconis(design.variables[!, var])
 
 """
     freedman_diaconis(design::SurveyDesign, var::Symbol)
 
-Calculate the number of bins for a `SurveyDesign`.
+Calculate the number of bins to use in a histogram using the Freedman-Diaconis rule.
 
 # Examples
 ```jldoctest
@@ -121,23 +40,6 @@ julia> freedman_diaconis(srs, :enroll)
 ```
 """
 freedman_diaconis(design::AbstractSurveyDesign, var::Symbol) = freedman_diaconis(design.data[!, var])
-
-"""
-    freedman_diaconis(design::svydesign, var::Symbol)
-
-Calculate the number of bins for a survey design variable.
-
-# Examples
-```jldoctest
-julia> apistrat = load_data("apistrat");
-
-julia> dstrat = svydesign(data = apistrat, id = :1, strata = :stype, weights = :pw, fpc = :fpc);
-
-julia> freedman_diaconis(dstrat, :enroll)
-15
-```
-"""
-freedman_diaconis(design::svydesign, var::Symbol) = freedman_diaconis(design.variables[!, var])
 
 """
     svyhist(design, var, bins = freedman_diaconis; normalization = :density, kwargs...)
@@ -184,9 +86,6 @@ function svyhist(design::AbstractSurveyDesign, var::Symbol,
     svyhist(design, var, bins(design, var); kwargs...)
 end
 
-"""
-Methods for `svydesign`.
-"""
 function svyhist(design::svydesign, var::Symbol,
 				 bins::Union{Integer, AbstractVector} = freedman_diaconis(design, var);
 				 normalization = :density,

--- a/src/svymean.jl
+++ b/src/svymean.jl
@@ -67,9 +67,7 @@ function svymean(x::Vector{Symbol}, design::SimpleRandomSample)
     return df
 end
 
-"""
-Inner method for `svyby`.
-"""
+# Inner methods for `svyby`
 function sem_svyby(x::AbstractVector, design::SimpleRandomSample, _)
     # domain size
     dsize = length(x)
@@ -82,10 +80,6 @@ function sem_svyby(x::AbstractVector, design::SimpleRandomSample, _)
     # return the standard error
     return sqrt(variance)
 end
-
-"""
-Inner method for `svyby`.
-"""
 function svymean(x::AbstractVector, design::SimpleRandomSample, weights)
     return DataFrame(mean = mean(x), sem = sem_svyby(x, design::SimpleRandomSample, weights))
 end

--- a/src/svyplot.jl
+++ b/src/svyplot.jl
@@ -19,9 +19,6 @@ function svyplot(design::AbstractSurveyDesign, x::Symbol, y::Symbol; kwargs...)
     data(design.data) * mapping(x, y, markersize = :weights) * visual(Scatter, marker = '￮') |> draw
 end
 
-"""
-Method for `svydesign`.
-"""
 function svyplot(design::svydesign, x::Symbol, y::Symbol; kwargs...)
 	data(design.variables) * mapping(x, y, markersize = :weights) * visual(Scatter, marker = '￮') |> draw
 end

--- a/src/svyquantile.jl
+++ b/src/svyquantile.jl
@@ -31,9 +31,6 @@ function svyquantile(var, design::StratifiedSample, q)
     return df
 end
 
-"""
-Method for `svydesign`.
-"""
 function svyquantile(var, design::svydesign, q)
     x = design.variables[!, var]
     w = design.variables.probs
@@ -43,9 +40,7 @@ function svyquantile(var, design::svydesign, q)
     return df
 end
 
-"""
-Inner method used by `svyby`.
-"""
+# Inner method for `svyby`
 function svyquantile(x, w, _, q)
     df = DataFrame(tmp = quantile(Float32.(x), weights(w), q))
     rename!(df, :tmp => Symbol(string(q) .* "th percentile"))

--- a/src/svytotal.jl
+++ b/src/svytotal.jl
@@ -46,9 +46,7 @@ function svytotal(x::Symbol, design::SimpleRandomSample)
     return DataFrame(total = total, se_total = se_tot(x, design::SimpleRandomSample))
 end
 
-"""
-Inner method for `svyby`.
-"""
+# Inner methods for `svyby`
 function se_total_svyby(x::AbstractVector, design::SimpleRandomSample, _)
     # vector of length equal to `sampsize` containing `x` and zeros
     z = cat(zeros(design.sampsize - length(x)), x; dims=1)
@@ -57,10 +55,6 @@ function se_total_svyby(x::AbstractVector, design::SimpleRandomSample, _)
     # return the standard error
     return sqrt(variance)
 end
-
-"""
-Inner method for `svyby`.
-"""
 function svytotal(x::AbstractVector, design::SimpleRandomSample, weights)
     total = wsum(x, weights)
     return DataFrame(total = total, sem = se_total_svyby(x, design::SimpleRandomSample, weights))


### PR DESCRIPTION
The warnings regarding the not-included docstrings are now gone. I changed `docs/make.jl` such that only the docs of exported functions and types are checked and I removed the docstrings from the functions that are not exported. In some places I replaced the docstrings with comments.

For the last warning (`Documenter could not auto-detect the building environment Skipping deployment.`) I could not find a solution. It seems that people are mostly ignoring it, although "Skipping deployment" doesn't sound ignorable.

Finally, I could not solve the first issue I mentioned [here](https://github.com/xKDR/Survey.jl/issues/42#issuecomment-1303446154), although I found out that the doctests actually don't pass on GitHub. They gave errors, even more errors than I had locally (you can see them if you go for example [here](https://github.com/xKDR/Survey.jl/actions/runs/3393681761/jobs/5641303991) at the "Build and deploy" stage), but somehow the job is completed. There might be a problem with our [workflow file](https://github.com/xKDR/Survey.jl/blob/612c832c27cbc3b3f1da136fcc5174b607814357/.github/workflows/documentation.yml). I could not replicate the errors locally, but I believe removing the unnecessary docstrings fixed them.