### PR TITLE
Change output of `svymean` and `svytotal` for `CategoricalArray` input

### DIFF
--- a/src/svymean.jl
+++ b/src/svymean.jl
@@ -45,18 +45,17 @@ julia> svymean(:enroll, srs)
 ```
 """
 function svymean(x::Symbol, design::SimpleRandomSample)
-    if isa(x, Symbol) && isa(design.data[!, x], CategoricalArray)
+    if isa(design.data[!, x], CategoricalArray)
         gdf = groupby(design.data, x)
         p = combine(gdf, nrow => :counts)
-        p.proportion = p.counts ./ sum(p.counts)
+        p.mean = p.counts ./ sum(p.counts)
         # variance of proportion
-        p.var = design.fpc .* p.proportion .* (1 .- p.proportion) ./ (design.sampsize - 1)
-        p.se = sqrt.(p.var)
-        return p
+        p.var = design.fpc .* p.mean .* (1 .- p.mean) ./ (design.sampsize - 1)
+        p.sem = sqrt.(p.var)
+        return select(p, Not([:counts, :var]))
     end
     return DataFrame(mean = mean(design.data[!, x]), sem = sem(x, design::SimpleRandomSample))
 end
-
 function svymean(x::Vector{Symbol}, design::SimpleRandomSample)
     means_list = []
     for i in x

--- a/src/svytotal.jl
+++ b/src/svytotal.jl
@@ -31,7 +31,7 @@ julia> svytotal(:enroll, srs)
 ```
 """
 function svytotal(x::Symbol, design::SimpleRandomSample)
-    if isa(x, Symbol) && isa(design.data[!, x], CategoricalArray)
+    if isa(design.data[!, x], CategoricalArray)
         gdf = groupby(design.data, x)
         p = combine(gdf, nrow => :count)
         p.total = design.popsize .* p.count ./ sum(p.count)
@@ -39,8 +39,8 @@ function svytotal(x::Symbol, design::SimpleRandomSample)
         p = select!(p, Not(:count)) # count column is not necessary for `svytotal`
         p.var = design.popsize^2 .* design.fpc .* p.proportion .*
                 (1 .- p.proportion) ./ (design.sampsize - 1) # N^2 .* variance of proportion
-        p.se = sqrt.(p.var)
-        return p
+        p.se_tot = sqrt.(p.var)
+        return select(p, Not([:proportion, :var]))
     end
     total = design.popsize * mean(design.data[!, x])
     return DataFrame(total = total, se_total = se_tot(x, design::SimpleRandomSample))


### PR DESCRIPTION
As mentioned [here](https://github.com/xKDR/Survey.jl/issues/52#issuecomment-1313635971) the outputs of these functions for different input types was not consistent. Now, for `Vector{Real}` and for `CategoricalArray` the outputs look like this:

```julia
julia> apisrs = load_data("apisrs");

julia> srs = SimpleRandomSample(apisrs; weights = :pw);

julia> srs.data.stype = categorical(srs.data.stype);

julia> svymean(:enroll, srs)
1×2 DataFrame
 Row │ mean     sem
     │ Float64  Float64
─────┼──────────────────
   1 │  584.61  27.3684
   
   julia> svymean(:stype, srs)
3×3 DataFrame
 Row │ stype  mean     sem
     │ Cat…   Float64  Float64
─────┼───────────────────────────
   1 │ E        0.71   0.0316428
   2 │ H        0.125  0.0230624
   3 │ M        0.165  0.025884
   ```
   
   For `svytotal` the results are not correct even for the total estimation:
   
   ```julia
   julia> svytotal(:stype, srs)
3×3 DataFrame
 Row │ stype  total    se_tot
     │ Cat…   Float64  Float64
─────┼─────────────────────────
   1 │ E      4397.74  195.995
   2 │ H       774.25  142.849
   3 │ M      1022.01  160.326
   ```
   
   Compared to R:
   
   ```R
   > library(survey)
   > data(api)
   > srs <- svydesign(id = ~1, weights = ~pw, data = apistrat)
   > svytotal(~stype, srs)
       total     SE
stypeE  4421 313.40
stypeH   755  92.70
stypeM  1018 124.99
```

@smishr Can you take a look at the total estimation and standard error of mean and total?