### PR TITLE
Remove extra docstrings and reorder methods

### DIFF
--- a/src/mean.jl
+++ b/src/mean.jl
@@ -2,6 +2,9 @@
     mean(x, design)
 Estimate the population mean of a variable of a simple random sample, and the corresponding standard error.
 
+The calculations were done according to the book [Sampling Techniques](https://www.academia.edu/29684662/Cochran_1977_Sampling_Techniques_Third_Edition)
+by William Cochran.
+
 ```jldoctest
 julia> apisrs = load_data("apisrs");
 
@@ -13,6 +16,25 @@ julia> mean(:enroll, srs)
      │ Float64  Float64 
 ─────┼──────────────────
    1 │  584.61  27.3684
+
+julia> mean([:api00, :api99], srs)
+2×3 DataFrame
+ Row │ names   mean     SE     
+     │ String  Float64  Float64 
+─────┼──────────────────────────
+   1 │ api00   656.585  9.24972
+   2 │ api99   624.685  9.5003
+
+julia> strat = load_data("apistrat"); 
+
+julia> dstrat = StratifiedSample(strat, :stype; popsize  = :fpc); 
+
+julia> mean(:api00, dstrat)
+1×2 DataFrame
+ Row │ mean     SE     
+     │ Float64  Float64 
+─────┼──────────────────
+   1 │ 662.287  9.40894
 ```
 """
 function mean(x::Symbol, design::SimpleRandomSample)
@@ -32,128 +54,12 @@ function mean(x::Symbol, design::SimpleRandomSample)
     return DataFrame(mean=mean(design.data[!, x]), SE=se(x, design))
 end
 
-"""
-    mean(x, design)
-Estimate the population mean of a variable of a simple random sample, and the corresponding standard error.
-
-```jldoctest
-julia> apisrs = load_data("apisrs");
-
-julia> srs = SimpleRandomSample(apisrs;popsize=:fpc);
-
-julia> mean([:api00, :api99], srs)
-2×3 DataFrame
- Row │ names   mean     SE     
-     │ String  Float64  Float64 
-─────┼──────────────────────────
-   1 │ api00   656.585  9.24972
-   2 │ api99   624.685  9.5003
-```
-"""
 function mean(x::Vector{Symbol}, design::SimpleRandomSample)
     df = reduce(vcat, [mean(i, design) for i in x])
     insertcols!(df, 1, :names => String.(x))
     return df
 end
 
-"""
-Estimate domain-wise mean.
-
-The calculations were done according to the book [Calibration Estimators in Survey Sampling] by Jean-Claude Deville and Carl-Erik Sarndal(https://www.tandfonline.com/doi/abs/10.1080/01621459.1992.10475217).
-```jldoctest
-julia> using Survey; 
-
-julia> srs = load_data("apisrs"); 
-
-julia> srs = SimpleRandomSample(srs; popsize = :fpc);
-
-julia> mean(:api00, :cname, srs) |> first
-DataFrameRow
- Row │ cname     mean     SE     
-     │ String15  Float64  Float64 
-─────┼────────────────────────────
-   1 │ Kern        573.6  42.8026
-```
-"""
-function mean(x::Symbol, by::Symbol, design::SimpleRandomSample) 
-    function domain_mean(x::AbstractVector, design::SimpleRandomSample, weights)
-        function se(x::AbstractVector, design::SimpleRandomSample)
-            nd = length(x)  # domain size
-            n = design.sampsize
-            fpc = design.fpc
-            variance = (nd / n)^(-2) / n * fpc * ((nd - 1) / (n - 1)) * var(x)
-            return sqrt(variance)
-        end
-        return DataFrame(mean=Statistics.mean(x), SE=se(x, design))
-    end
-    gdf = groupby(design.data, by)
-    combine(gdf, [x, :weights] => ((a, b) -> domain_mean(a, design, b)) => AsTable)
-end
-
-"""
-Calculates domain mean and its std error, based example 10.3.3 on pg394 Sarndal (1992)
-
-```jldoctest
-julia> using Survey;
-
-julia> strat = load_data("apistrat");
-
-julia> dstrat = StratifiedSample(strat, :stype; popsize  = :fpc);
-
-julia> mean(:api00, :cname, dstrat) |> first 
-DataFrameRow
- Row │ cname        mean     SE      
-     │ String15     Float64  Float64 
-─────┼───────────────────────────────
-   1 │ Los Angeles  633.511  21.3912
-```
-"""
-function mean(x::Symbol, by::Symbol, design::StratifiedSample)
-    function domain_mean(x::AbstractVector, popsize::AbstractVector, sampsize::AbstractVector, sampfraction::AbstractVector, strata::AbstractVector)
-        df = DataFrame(x=x, popsize=popsize, sampsize=sampsize, sampfraction=sampfraction, strata=strata)
-        function calculate_components(x, popsize, sampsize, sampfraction)
-            return DataFrame(
-                nsdh = length(x),
-                nsh = length(x),
-                substrata_domain_totals = sum(x),
-                ȳsdh = mean(x),
-                Nh = first(popsize),
-                nh = first(sampsize),
-                fh = first(sampfraction),
-                sigma_ȳsh_squares = sum((x .- mean(x)).^2)
-                )
-        end
-        components = combine(groupby(df, :strata), [:x, :popsize, :sampsize, :sampfraction] => calculate_components => AsTable)
-        domain_mean = sum(components.Nh .* components.substrata_domain_totals ./ components.nh) / sum(components.Nh .* components.nsdh ./ components.nh)
-        pdh = components.nsdh ./ components.nh
-        N̂d = sum(components.Nh .* pdh)
-        domain_var = sum(components.Nh .^ 2 .* (1 .- components.fh) .* (components.sigma_ȳsh_squares .+ (components.nsdh .* (1 .- pdh) .* (components.ȳsdh .- domain_mean) .^ 2)) ./ (components.nh .* (components.nh .- 1))) ./ N̂d .^ 2
-        domain_mean_se = sqrt(domain_var)
-        return DataFrame(mean=domain_mean, SE=domain_mean_se)
-    end
-    gdf_domain = groupby(design.data, by)
-    combine(gdf_domain, [x, :popsize,:sampsize,:sampfraction, design.strata] => domain_mean => AsTable)
-end
-"""
-Estimate the population mean of a variable of a stratified sample, and the corresponding standard error.
-    Ref: Cochran (1977)
-
-```jldoctest
-julia> using Survey; 
-
-julia> strat = load_data("apistrat"); 
-
-julia> dstrat = StratifiedSample(strat, :stype; popsize  = :fpc); 
-
-julia> mean(:api00, dstrat)
-1×2 DataFrame
- Row │ mean     SE     
-     │ Float64  Float64 
-─────┼──────────────────
-   1 │ 662.287  9.40894
-
-```
-"""
 function mean(x::Symbol, design::StratifiedSample)
     if x == design.strata
         gdf = groupby(design.data, x)
@@ -181,6 +87,80 @@ function mean(x::Symbol, design::StratifiedSample)
     V̂Ȳ̂ = sum((Wₕ .^ 2) .* (1 .- fₕ) .* s²ₕ ./ nₕ)
     SE = sqrt(V̂Ȳ̂)
     return DataFrame(mean=Ȳ̂, SE=SE)
+end
+
+"""
+Estimate domain-wise mean.
+
+The calculations were done according to the book [Calibration Estimators in Survey Sampling](https://www.tandfonline.com/doi/abs/10.1080/01621459.1992.10475217)
+by Jean-Claude Deville and Carl-Erik Sarndal.
+
+```jldoctest
+julia> using Survey; 
+
+julia> srs = load_data("apisrs"); 
+
+julia> srs = SimpleRandomSample(srs; popsize = :fpc);
+
+julia> mean(:api00, :cname, srs) |> first
+DataFrameRow
+ Row │ cname     mean     SE     
+     │ String15  Float64  Float64 
+─────┼────────────────────────────
+   1 │ Kern        573.6  42.8026
+
+julia> strat = load_data("apistrat");
+
+julia> dstrat = StratifiedSample(strat, :stype; popsize  = :fpc);
+
+julia> mean(:api00, :cname, dstrat) |> first 
+DataFrameRow
+ Row │ cname        mean     SE      
+     │ String15     Float64  Float64 
+─────┼───────────────────────────────
+   1 │ Los Angeles  633.511  21.3912
+```
+"""
+function mean(x::Symbol, by::Symbol, design::SimpleRandomSample) 
+    function domain_mean(x::AbstractVector, design::SimpleRandomSample, weights)
+        function se(x::AbstractVector, design::SimpleRandomSample)
+            nd = length(x)  # domain size
+            n = design.sampsize
+            fpc = design.fpc
+            variance = (nd / n)^(-2) / n * fpc * ((nd - 1) / (n - 1)) * var(x)
+            return sqrt(variance)
+        end
+        return DataFrame(mean=Statistics.mean(x), SE=se(x, design))
+    end
+    gdf = groupby(design.data, by)
+    combine(gdf, [x, :weights] => ((a, b) -> domain_mean(a, design, b)) => AsTable)
+end
+
+function mean(x::Symbol, by::Symbol, design::StratifiedSample)
+    function domain_mean(x::AbstractVector, popsize::AbstractVector, sampsize::AbstractVector, sampfraction::AbstractVector, strata::AbstractVector)
+        df = DataFrame(x=x, popsize=popsize, sampsize=sampsize, sampfraction=sampfraction, strata=strata)
+        function calculate_components(x, popsize, sampsize, sampfraction)
+            return DataFrame(
+                nsdh = length(x),
+                nsh = length(x),
+                substrata_domain_totals = sum(x),
+                ȳsdh = mean(x),
+                Nh = first(popsize),
+                nh = first(sampsize),
+                fh = first(sampfraction),
+                sigma_ȳsh_squares = sum((x .- mean(x)).^2)
+                )
+        end
+        components = combine(groupby(df, :strata), [:x, :popsize, :sampsize, :sampfraction] => calculate_components => AsTable)
+        domain_mean = sum(components.Nh .* components.substrata_domain_totals ./ components.nh) / sum(components.Nh .* components.nsdh ./ components.nh)
+        pdh = components.nsdh ./ components.nh
+        N̂d = sum(components.Nh .* pdh)
+        domain_var = sum(components.Nh .^ 2 .* (1 .- components.fh) .* (components.sigma_ȳsh_squares .+ (components.nsdh .* (1 .- pdh) .* (components.ȳsdh .- domain_mean) .^ 2)) ./ (components.nh .* (components.nh .- 1))) ./ N̂d .^ 2
+        domain_mean_se = sqrt(domain_var)
+        return DataFrame(mean=domain_mean, SE=domain_mean_se)
+    end
+    gdf_domain = groupby(design.data, by)
+    combine(gdf_domain, [x, :popsize,:sampsize,:sampfraction, design.strata] => domain_mean => AsTable)
 end
 
 function mean(::Bool; x::Symbol, design::StratifiedSample)


### PR DESCRIPTION
I reordered the methods such that the first methods correspond to the main functionality (calculating the mean of a survey design variable) and the last methods correspond to the `by` functionality (calculating the mean of a variable from a subpopulation). The very last method is not part of these, we should discuss on issue #109 what to do with it.

After reordering, I removed the docstrings from all methods apart from the first one for each group and I added relevant examples for all methods inside that docstring.