### PR TITLE
Consistent variable naming and docs for `bootweights`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ probs: [0.0295, 0.0295, 0.0295  …  0.0295]
 
 julia> apiclus2 = load_data("apiclus2");
 
-julia> clus_two_stage = SurveyDesign(apiclus2; clusters=[:dnum, :snum], weights=:pw)
+julia> dclus2 = SurveyDesign(apiclus2; clusters=[:dnum, :snum], weights=:pw)
 SurveyDesign:
 data: 126×47 DataFrame
 strata: none

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ developed by [Professor Thomas Lumley](https://www.stat.auckland.ac.nz/people/tl
 
 All types of survey design are supported by this package.
 
-> **_NOTE:_**  For multistage sampling a single stage approximation is used. For
-more information see the [TODO](https://xkdr.github.io/Survey.jl/dev/) section of
-the documentation.
+> **_NOTE:_**  For multistage sampling a single stage approximation is used.[^1]
 
 ## Installation
 ```julia
@@ -175,3 +173,7 @@ contains a list of features that contributors can implement in the short-term.
 ## Support
 
 We gratefully acknowledge the JuliaLab at MIT for financial support for this project.
+
+## References
+
+[^1]: [Lumley, Thomas. Complex surveys: a guide to analysis using R. John Wiley & Sons, 2011.](https://books.google.co.in/books?hl=en&lr=&id=L96ludyhFBsC&oi=fnd&pg=PP12&dq=complex+surveys+lumley&ots=ie0y1lnzv1&sig=c4UHI3arjspMJ6OYzlX32E9rNRI#v=onepage&q=complex%20surveys%20lumley&f=false) Page 44

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ probs: [0.0323, 0.0323, 0.0323  …  0.0323]
 
 julia> apistrat = load_data("apistrat");
 
-julia> strat = SurveyDesign(apistrat; strata=:stype, weights=:pw)
+julia> dstrat = SurveyDesign(apistrat; strata=:stype, weights=:pw)
 SurveyDesign:
 data: 200×46 DataFrame
 strata: stype
@@ -64,7 +64,7 @@ probs: [0.0226, 0.0226, 0.0226  …  0.0662]
 
 julia> apiclus1 = load_data("apiclus1");
 
-julia> clus_one_stage = SurveyDesign(apiclus1; clusters=:dnum, weights=:pw)
+julia> dclus1 = SurveyDesign(apiclus1; clusters=:dnum, weights=:pw)
 SurveyDesign:
 data: 183×46 DataFrame
 strata: none

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ This package is used to study complex survey data. It aims to provide an efficie
 
 Surveys are a standard tool for empirical research in social and behavioral sciences, and also widely used by governments and businesses alike. In order to get a better representation or more precise estimates, complex surveys use sophisticated sampling techniques like clustering, stratification, unequal probability selection or a combination of these. Computing population estimates from a survey with corresponding standard errors requires several corrections, weights calibrations and adjustments, wherein stems the need for a "survey" package which automatically applies these mathematical techniques.
 
-Several software tools are available to study complex surveys[^10]. The R[^12](https://r-survey.r-forge.r-project.org/survey/) package is a widely used open-source package. 
+Several software tools are available to study complex surveys[^10]. The R[^12] package is a widely used open-source package. 
 
 ## Why a package for survey analysis in Julia?
 

--- a/docs/src/man/comparisons.md
+++ b/docs/src/man/comparisons.md
@@ -31,13 +31,13 @@ julia> srs = load_data("apisrs")
 
 ```R
 > srs = svydesign(id=~1, data=apisrs, weights=~pw) # simple random sample
-> strat = svydesign(id=~1, data=apistrat, strata=~stype, weights=~pw) # stratified
+> dstrat = svydesign(id=~1, data=apistrat, strata=~stype, weights=~pw) # stratified
 > clus1 = svydesign(id=~dnum, data=apiclus1, weights=~pw) # clustered (one stage)
 ```
 
 ```julia
 julia> srs = SurveyDesign(apisrs; weights=:pw) # simple random sample
-julia> strat = SurveyDesign(apistrat; strata=:stype, weights=:pw) # stratified
+julia> dstrat = SurveyDesign(apistrat; strata=:stype, weights=:pw) # stratified
 julia> clus1 = SurveyDesign(apiclus1; clusters=:dnum, weights=:pw) # clustered (one stage)
 ```
 

--- a/docs/src/man/dataframes.md
+++ b/docs/src/man/dataframes.md
@@ -47,7 +47,7 @@ Five columns were added:
 
 ```@repl manual_DataFrames
 apistrat = load_data("apistrat");
-strat = SurveyDesign(apistrat; strata=:stype, weights=:pw);
+dstrat = SurveyDesign(apistrat; strata=:stype, weights=:pw);
 apistrat[:, [:stype, :_sampsize, :_popsize]]
 ```
 

--- a/docs/src/man/replicate.md
+++ b/docs/src/man/replicate.md
@@ -11,27 +11,27 @@ For example:
 ```@repl bootstrap
 using Survey
 apistrat = load_data("apistrat")
-strat = SurveyDesign(apistrat; strata=:stype, weights=:pw)
-strat_boot = bootweights(strat; replicates = 10)
+dstrat = SurveyDesign(apistrat; strata=:stype, weights=:pw)
+bstrat = bootweights(dstrat; replicates = 10)
 ```
 
 For each replicate, the `DataFrame` of `ReplicateDesign` has an additional column. The of the column is `replicate_` followed by the replicate number.  
 
 ```@repl bootstrap
-names(strat_boot.data)
+names(bstrat.data)
 ```
 `replicate_1`, `replicate_2`, `replicate_3`, `replicate_4`, `replicate_5`, `replicate_6`, `replicate_7`, `replicate_8`, `replicate_9`, `replicate_10`, are the replicate weight columns. 
 
 While a `SurveyDesign` can be used to estimate a statistics. For example: 
 
 ```@repl bootstrap
-mean(:api00, strat)
+mean(:api00, dstrat)
 ```
 
 The `ReplicateDesign` can be used to compute the standard error of the statistic. For example: 
 
 ```@repl bootstrap
-mean(:api00, strat_boot)
+mean(:api00, bstrat)
 ```
 
 For each replicate weight, the statistic is calculated using it instead of the weight. The standard deviation of those statistics is the standard error of the estimate.  

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -115,9 +115,9 @@ Survey design obtained by replicating an original design using [`bootweights`](@
 ```jldoctest
 julia> apistrat = load_data("apistrat");
 
-julia> strat = SurveyDesign(apistrat; strata=:stype, weights=:pw);
+julia> dstrat = SurveyDesign(apistrat; strata=:stype, weights=:pw);
 
-julia> bootstrat = bootweights(strat; replicates=1000)
+julia> bootstrat = bootweights(dstrat; replicates=1000)
 ReplicateDesign:
 data: 200×1044 DataFrame
 strata: stype

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -6,9 +6,9 @@ julia> using Random
 
 julia> apiclus1 = load_data("apiclus1");
 
-julia> clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, popsize=:fpc);
+julia> dclus1 = SurveyDesign(apiclus1; clusters = :dnum, popsize=:fpc);
 
-julia> bootweights(clus_one_stage; replicates=1000, rng=MersenneTwister(111)) # choose a seed for deterministic results
+julia> bootweights(dclus1; replicates=1000, rng=MersenneTwister(111)) # choose a seed for deterministic results
 ReplicateDesign:
 data: 183×1044 DataFrame
 strata: none

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -6,7 +6,7 @@ Estimate the mean of a variable.
 ```jldoctest
 julia> apiclus1 = load_data("apiclus1");
 
-julia> clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw)
+julia> dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw)
 SurveyDesign:
 data: 183×44 DataFrame
 strata: none
@@ -17,7 +17,7 @@ sampsize: [15, 15, 15  …  15]
 weights: [33.847, 33.847, 33.847  …  33.847]
 allprobs: [0.0295, 0.0295, 0.0295  …  0.0295]
 
-julia> mean(:api00, clus_one_stage)
+julia> mean(:api00, dclus1)
 1×1 DataFrame
  Row │ mean
      │ Float64
@@ -34,10 +34,10 @@ end
 
 Use replicate weights to compute the standard error of the estimated mean. 
 
-```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
-julia> clus_one_stage_boot = clus_one_stage |> bootweights;
+```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
+julia> bclus1 = dclus1 |> bootweights;
 
-julia> mean(:api00, clus_one_stage_boot)
+julia> mean(:api00, bclus1)
 1×2 DataFrame
  Row │ mean     SE
      │ Float64  Float64
@@ -55,8 +55,8 @@ end
 """
 Estimate the mean of a list of variables.
 
-```jldoctest meanlabel; setup = :(apiclus1 = load_data("apiclus1"); clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); clus_one_stage_boot = clus_one_stage |> bootweights)
-julia> mean([:api00, :enroll], clus_one_stage)
+```jldoctest meanlabel; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); bclus1 = dclus1 |> bootweights)
+julia> mean([:api00, :enroll], dclus1)
 2×2 DataFrame
  Row │ names   mean
      │ String  Float64
@@ -68,7 +68,7 @@ julia> mean([:api00, :enroll], clus_one_stage)
 Use replicate weights to compute the standard error of the estimated means. 
 
 ```jldoctest meanlabel
-julia> mean([:api00, :enroll], clus_one_stage_boot)
+julia> mean([:api00, :enroll], bclus1)
 2×3 DataFrame
  Row │ names   mean     SE
      │ String  Float64  Float64
@@ -88,8 +88,8 @@ end
 
 Estimate means of domains.
 
-```jldoctest meanlabel; setup = :(apiclus1 = load_data("apiclus1"); clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); clus_one_stage_boot = clus_one_stage |> bootweights)
-julia> mean(:api00, :cname, clus_one_stage)
+```jldoctest meanlabel; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); bclus1 = dclus1 |> bootweights)
+julia> mean(:api00, :cname, dclus1)
 11×2 DataFrame
  Row │ cname        mean
      │ String15     Float64
@@ -109,7 +109,7 @@ julia> mean(:api00, :cname, clus_one_stage)
 Use the replicate design to compute standard errors of the estimated means. 
 
 ```jldoctest meanlabel
-julia> mean(:api00, :cname, clus_one_stage_boot)
+julia> mean(:api00, :cname, bclus1)
 11×3 DataFrame
  Row │ cname        mean     SE
      │ String15     Float64  Float64

--- a/src/quantile.jl
+++ b/src/quantile.jl
@@ -36,9 +36,9 @@ end
 Use replicate weights to compute the standard error of the estimated quantile. 
 
 ```jldoctest; setup = :(apisrs = load_data("apisrs");srs = SurveyDesign(apisrs; weights=:pw))
-julia> srs_boot = srs |> bootweights; 
+julia> bsrs = srs |> bootweights; 
 
-julia> quantile(:api00, srs_boot, 0.5)
+julia> quantile(:api00, bsrs, 0.5)
 1×2 DataFrame
  Row │ 0.5th percentile  SE
      │ Float64           Float64
@@ -84,8 +84,8 @@ end
 
 Use replicate weights to compute the standard errors of the estimated quantiles. 
 
-```jldoctest; setup = :(apisrs = load_data("apisrs"); srs = SurveyDesign(apisrs; weights=:pw); srs_boot = SurveyDesign(apisrs; weights=:pw) |> bootweights)
-julia> quantile(:enroll, srs_boot, [0.1,0.2,0.5,0.75,0.95])
+```jldoctest; setup = :(apisrs = load_data("apisrs"); srs = SurveyDesign(apisrs; weights=:pw); bsrs = SurveyDesign(apisrs; weights=:pw) |> bootweights)
+julia> quantile(:enroll, bsrs, [0.1,0.2,0.5,0.75,0.95])
 5×3 DataFrame
  Row │ percentile  statistic  SE       
      │ String      Float64    Float64  

--- a/src/ratio.jl
+++ b/src/ratio.jl
@@ -26,12 +26,14 @@ end
 Use replicate weights to compute the standard error of the ratio.
 
 ```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
-julia> ratio(:api00, :enroll, clus_one_stage)
-1×1 DataFrame
- Row │ ratio
-     │ Float64
-─────┼─────────
-   1 │ 1.17182
+julia> bclus1 = bootweights(clus_one_stage); 
+
+julia> ratio(:api00, :enroll, bclus1)
+1×2 DataFrame
+ Row │ ratio    SE
+     │ Float64  Float64
+─────┼───────────────────
+   1 │ 1.17182  0.131518
 
 ```
 """

--- a/src/ratio.jl
+++ b/src/ratio.jl
@@ -6,9 +6,9 @@ Estimate the ratio of the columns specified in numerator and denominator.
 ```jldoctest
 julia> apiclus1 = load_data("apiclus1");
 
-julia> clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw);
+julia> dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw);
 
-julia> ratio(:api00, :enroll, clus_one_stage)
+julia> ratio(:api00, :enroll, dclus1)
 1×1 DataFrame
  Row │ ratio
      │ Float64
@@ -25,8 +25,8 @@ end
 """
 Use replicate weights to compute the standard error of the ratio.
 
-```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
-julia> bclus1 = bootweights(clus_one_stage); 
+```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
+julia> bclus1 = bootweights(dclus1); 
 
 julia> ratio(:api00, :enroll, bclus1)
 1×2 DataFrame

--- a/src/total.jl
+++ b/src/total.jl
@@ -6,9 +6,9 @@ Estimate the population total of variable.
 ```jldoctest
 julia> apiclus1 = load_data("apiclus1");
 
-julia> clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw);
+julia> dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw);
 
-julia> total(:api00, clus_one_stage)
+julia> total(:api00, dclus1)
 1×1 DataFrame
  Row │ total
      │ Float64
@@ -24,10 +24,10 @@ end
 """
 Use replicate weights to compute the standard error of the estimated total. 
 
-```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
-julia> clus_one_stage_boot = clus_one_stage |> bootweights;
+```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
+julia> bclus1 = dclus1 |> bootweights;
 
-julia> total(:api00, clus_one_stage_boot)
+julia> total(:api00, bclus1)
 1×2 DataFrame
  Row │ total      SE
      │ Float64    Float64
@@ -45,8 +45,8 @@ end
 """
 Estimate the population total of a list of variables.
 
-```jldoctest totallabel; setup = :(apiclus1 = load_data("apiclus1"); clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); clus_one_stage_boot = clus_one_stage |> bootweights)
-julia> total([:api00, :enroll], clus_one_stage)
+```jldoctest totallabel; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); bclus1 = dclus1 |> bootweights)
+julia> total([:api00, :enroll], dclus1)
 2×2 DataFrame
  Row │ names   total
      │ String  Float64
@@ -58,7 +58,7 @@ julia> total([:api00, :enroll], clus_one_stage)
 Use replicate weights to compute the standard error of the estimated means. 
 
 ```jldoctest totallabel
-julia> total([:api00, :enroll], clus_one_stage_boot)
+julia> total([:api00, :enroll], bclus1)
 2×3 DataFrame
  Row │ names   total      SE
      │ String  Float64    Float64
@@ -78,8 +78,8 @@ end
 
 Estimate population totals of domains.
 
-```jldoctest totallabel; setup = :(apiclus1 = load_data("apiclus1"); clus_one_stage = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); clus_one_stage_boot = clus_one_stage |> bootweights)
-julia> total(:api00, :cname, clus_one_stage)
+```jldoctest totallabel; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); bclus1 = dclus1 |> bootweights)
+julia> total(:api00, :cname, dclus1)
 11×2 DataFrame
  Row │ cname        total
      │ String15     Float64
@@ -99,7 +99,7 @@ julia> total(:api00, :cname, clus_one_stage)
 Use the replicate design to compute standard errors of the estimated totals. 
 
 ```jldoctest totallabel
-julia> total(:api00, :cname, clus_one_stage_boot)
+julia> total(:api00, :cname, bclus1)
 11×3 DataFrame
  Row │ cname        total           SE
      │ String15     Float64         Float64

--- a/test/mean.jl
+++ b/test/mean.jl
@@ -7,13 +7,13 @@
     @test mean_vec_sym.mean[1] ≈ 656.585 atol = 1e-4
     @test mean_vec_sym.mean[2] ≈ 584.61 atol = 1e-4
 
-    @test mean(:api00, srs_boot).mean[1] ≈ 656.585 atol = 1e-4
-    @test mean(:api00, srs_boot).SE[1] ≈ 9.402772170880636 atol = 1e-1
-    @test mean(:enroll, srs_boot).mean[1] ≈ 584.61 atol = 1e-4
-    @test mean(:enroll, srs_boot).SE[1] ≈ 27.821214737089324 atol = 1
+    @test mean(:api00, bsrs).mean[1] ≈ 656.585 atol = 1e-4
+    @test mean(:api00, bsrs).SE[1] ≈ 9.402772170880636 atol = 1e-1
+    @test mean(:enroll, bsrs).mean[1] ≈ 584.61 atol = 1e-4
+    @test mean(:enroll, bsrs).SE[1] ≈ 27.821214737089324 atol = 1
     ##############################
     ### Vector of Symbols
-    mean_vec_sym = mean([:api00,:enroll], srs_boot)
+    mean_vec_sym = mean([:api00,:enroll], bsrs)
     @test mean_vec_sym.mean[1] ≈ 656.585 atol = 1e-4
     @test mean_vec_sym.SE[1] ≈ 9.3065 rtol = 1e-1
     @test mean_vec_sym.mean[2] ≈ 584.61 atol = 1e-4
@@ -29,9 +29,9 @@
 end
 
 @testset "mean_Stratified" begin
-    mean_strat = mean(:api00, strat)
+    mean_strat = mean(:api00, dstrat)
     @test mean_strat.mean[1] ≈ 662.29 rtol = 1e-1
-    mean_strat = mean(:api00, strat_boot)
+    mean_strat = mean(:api00, bstrat)
     @test mean_strat.mean[1] ≈ 662.29 rtol = 1e-1
     @test mean_strat.SE[1] ≈ 9.48296 atol = 1e-1
 end
@@ -42,7 +42,7 @@ end
     @test mean_symb_srs.mean[2] ≈ 666.141 rtol = 1e-1
     @test mean_symb_srs.mean[3] ≈ 654.273 rtol = 1e-1
 
-    mean_symb_srs = mean(:api00, :stype, srs_boot)
+    mean_symb_srs = mean(:api00, :stype, bsrs)
     @test mean_symb_srs.mean[1] ≈ 605.36 rtol = 1e-1
     @test mean_symb_srs.mean[2] ≈ 666.141 rtol = 1e-1
     @test mean_symb_srs.mean[3] ≈ 654.273 rtol = 1e-1
@@ -52,12 +52,12 @@ end
 end
 
 @testset "mean_svyby_Stratified" begin
-    mean_strat_symb = mean(:api00, :stype, strat)
+    mean_strat_symb = mean(:api00, :stype, dstrat)
     @test mean_strat_symb.mean[1] ≈ 674.43 rtol = 1e-1
     @test mean_strat_symb.mean[2] ≈ 636.6 rtol = 1e-1
     @test mean_strat_symb.mean[3] ≈ 625.82 rtol = 1e-1
 
-    mean_strat_symb = mean(:api00, :stype, strat_boot)
+    mean_strat_symb = mean(:api00, :stype, bstrat)
     @test mean_strat_symb.mean[1] ≈ 674.43 rtol = 1e-1
     @test mean_strat_symb.mean[2] ≈ 636.6 rtol = 1e-1
     @test mean_strat_symb.mean[3] ≈ 625.82 rtol = 1e-1

--- a/test/quantile.jl
+++ b/test/quantile.jl
@@ -1,8 +1,8 @@
 @testset "quantile_SimpleRandomSample" begin
     @test quantile(:api00, srs, 0.5)[!,1][1] ≈ 659.0 atol=1e-4
-    @test quantile(:api00, srs_boot, 0.5)[!,1][1] ≈ 659.0 atol=1e-4
-    @test quantile(:api00, srs_boot, [0.1753,0.25,0.5,0.75,0.975])[!,2] ≈ [512.8847,544,659,752.5,905] rtol = 1e-4
-    @test quantile(:api00, srs_boot, [0.1753,0.25,0.5,0.75,0.975])[!,3] ≈ [14.6761,12.7793,14.9763,10.7707,11.2990] rtol = 1e-4
-    @test quantile(:enroll,srs_boot, [0.1,0.2,0.5,0.75,0.95])[!,2] ≈ [245.5,317.6,453.0,668.5,1473.1] rtol = 1e-4 
+    @test quantile(:api00, bsrs, 0.5)[!,1][1] ≈ 659.0 atol=1e-4
+    @test quantile(:api00, bsrs, [0.1753,0.25,0.5,0.75,0.975])[!,2] ≈ [512.8847,544,659,752.5,905] rtol = 1e-4
+    @test quantile(:api00, bsrs, [0.1753,0.25,0.5,0.75,0.975])[!,3] ≈ [14.6761,12.7793,14.9763,10.7707,11.2990] rtol = 1e-4
+    @test quantile(:enroll,bsrs, [0.1,0.2,0.5,0.75,0.95])[!,2] ≈ [245.5,317.6,453.0,668.5,1473.1] rtol = 1e-4 
     @test quantile(:enroll,srs, [0.1,0.2,0.5,0.75,0.95])[!,2] ≈ [245.5,317.6,453.0,668.5,1473.1] rtol = 1e-4 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,11 +8,11 @@ const SE_TOL = 1e-1
 # Simple random sample
 apisrs = load_data("apisrs") # Load API dataset
 srs = SurveyDesign(apisrs, weights = :pw) 
-srs_boot = srs |> bootweights # Create replicate design
+bsrs = srs |> bootweights # Create replicate design
 # Stratified sample
 apistrat = load_data("apistrat") # Load API dataset
-strat = SurveyDesign(apistrat, strata = :stype, weights = :pw) # Create SurveyDesign
-strat_boot = strat |> bootweights # Create replicate design
+dstrat = SurveyDesign(apistrat, strata = :stype, weights = :pw) # Create SurveyDesign
+bstrat = dstrat |> bootweights # Create replicate design
 
 # One-stage cluster sample
 apiclus1 = load_data("apiclus1") # Load API dataset

--- a/test/show.jl
+++ b/test/show.jl
@@ -25,7 +25,7 @@
     allprobs: [0.0323, 0.0323, 0.0323  …  0.0323]
     replicates: 4000"""
 
-    show(io, MIME("text/plain"), srs_boot)
+    show(io, MIME("text/plain"), bsrs)
     strb = String(take!(io))
     @test strb == refstrb
 end
@@ -44,7 +44,7 @@ end
     weights: [44.21, 44.21, 44.21  …  15.1]
     allprobs: [0.0226, 0.0226, 0.0226  …  0.0662]"""
 
-    show(io, MIME("text/plain"), strat)
+    show(io, MIME("text/plain"), dstrat)
     str = String(take!(io))
     @test str == refstr
 
@@ -60,7 +60,7 @@ end
     allprobs: [0.0226, 0.0226, 0.0226  …  0.0662]
     replicates: 4000"""
 
-    show(io, MIME("text/plain"), strat_boot)
+    show(io, MIME("text/plain"), bstrat)
     strb = String(take!(io))
     @test strb == refstrb
 end

--- a/test/total.jl
+++ b/test/total.jl
@@ -4,7 +4,7 @@
     tot = total(:api00, srs)
     @test tot.total[1] ≈ 4066888 rtol = STAT_TOL
 
-    tot = total(:api00, srs_boot)
+    tot = total(:api00, bsrs)
     @test tot.total[1] ≈ 4066888 rtol = STAT_TOL
     @test tot.SE[1] ≈ 58526 rtol = SE_TOL
     # equivalent R code and results:
@@ -23,7 +23,7 @@
     @test tot.total[1] ≈ 4066888 rtol = STAT_TOL
     ## :enroll
     @test tot.total[2] ≈ 3621074 rtol = STAT_TOL
-    tot = total([:api00, :enroll], srs_boot)
+    tot = total([:api00, :enroll], bsrs)
     ## :api00
     @test tot.total[1] ≈ 4066888 rtol = STAT_TOL
     @test tot.SE[1] ≈ 57502 rtol = SE_TOL
@@ -46,7 +46,7 @@
     @test filter(:cname => ==("Los Angeles"), tot).total[1] ≈ 917238.49 rtol = STAT_TOL
     @test filter(:cname => ==("Monterey"), tot).total[1] ≈ 74947.40 rtol = STAT_TOL
 
-    tot = total(:api00, :cname, srs_boot)
+    tot = total(:api00, :cname, bsrs)
     @test size(tot)[1] == apisrs.cname |> unique |> length
     @test filter(:cname => ==("Los Angeles"), tot).total[1] ≈ 917238.49 rtol = STAT_TOL
     @test filter(:cname => ==("Los Angeles"), tot).SE[1] ≈ 122193.02 rtol = SE_TOL
@@ -59,15 +59,15 @@ end
 
 @testset "total Stratified" begin
     # base functionality
-    tot = total(:api00, strat)
+    tot = total(:api00, dstrat)
     @test tot.total[1] ≈ 4102208 rtol = STAT_TOL
 
-    tot = total(:api00, strat_boot)
+    tot = total(:api00, bstrat)
     @test tot.total[1] ≈ 4102208 rtol = STAT_TOL
     @test tot.SE[1] ≈ 60746 rtol = SE_TOL
     # equivalent R code and results:
-    # > strat <- svydesign(data=apistrat, id=~1, weights=~pw, strata=~stype)
-    # > stratrep <- as.svrepdesign(strat, type="bootstrap", replicates=4000)
+    # > dstrat <- svydesign(data=apistrat, id=~1, weights=~pw, strata=~stype)
+    # > stratrep <- as.svrepdesign(dstrat, type="bootstrap", replicates=4000)
     # > svytotal(~api00, stratrep)
     #     total    SE
     # api00 4102208 60746
@@ -76,11 +76,11 @@ end
     # api00 662.29 9.8072
 
     # Vector{Symbol}
-    tot = total([:api00, :enroll], strat)
+    tot = total([:api00, :enroll], dstrat)
     @test tot.total[1] ≈ 4102208 rtol = STAT_TOL ## :api00
     @test tot.total[2] ≈ 3687178 rtol = STAT_TOL ## :enroll
 
-    tot = total([:api00, :enroll], strat_boot)
+    tot = total([:api00, :enroll], bstrat)
      ## :api00
     @test tot.total[1] ≈ 4102208 rtol = STAT_TOL
     @test tot.SE[1] ≈ 60746 rtol = SE_TOL
@@ -95,12 +95,12 @@ end
     # enroll 595.28 18.9412
 
     # subpopulation
-    tot = total(:api00, :cname, strat)
+    tot = total(:api00, :cname, dstrat)
     @test size(tot)[1] == apistrat.cname |> unique |> length
     @test filter(:cname => ==("Los Angeles"), tot).total[1] ≈ 869905.98 rtol = STAT_TOL
     @test filter(:cname => ==("Monterey"), tot).total[1] ≈ 72103.09 rtol = STAT_TOL
 
-    tot = total(:api00, :cname, strat_boot)
+    tot = total(:api00, :cname, bstrat)
     @test size(tot)[1] == apistrat.cname |> unique |> length
     @test filter(:cname => ==("Los Angeles"), tot).total[1] ≈ 869905.98 rtol = STAT_TOL
     @test filter(:cname => ==("Los Angeles"), tot).SE[1] ≈ 134195.81 rtol = SE_TOL


### PR DESCRIPTION
1. Variable names for the same object were different. For example: `dclus1`, `clus1` and `clus_one_strage`. I have tried to make things consistent. I use variable names that are similar to what the R survey documentation has done. 
2. Remove TODO from readme and add reference to Lumley's book
3. Add explanation for `bootweights` in the docstring. 
