### PR TITLE
Remove extra things from the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 [![codecov](https://codecov.io/gh/xKDR/Survey.jl/branch/main/graph/badge.svg?token=4PFSF47BT2)](https://codecov.io/gh/xKDR/Survey.jl)
 [![Milestones](https://img.shields.io/badge/-milestones-brightgreen)](https://github.com/xKDR/Survey.jl/milestones)
 
-This package is used to study complex survey data. It aims to be a fast alternative
-to the [Survey package in R](https://cran.r-project.org/web/packages/survey/index.html)
-developed by [Professor Thomas Lumley](https://www.stat.auckland.ac.nz/people/tlum005).
-
+This package is used to study complex survey data. It aims to provide an efficient computing framework for large survey data. 
 All types of survey design are supported by this package.
 
 > **_NOTE:_**  For multistage sampling a single stage approximation is used.[^1]

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -35,11 +35,6 @@ the [Academic Performance Index](https://r-survey.r-forge.r-project.org/survey/h
 schools with at least 100 students and for various probability samples of the
 data.
 
-!!! note
-
-    The API program has been discontinued at the end of 2018. Information is archived
-    [here](https://www.cde.ca.gov/re/pr/api.asp).
-
 ```@repl tutorial
 apisrs = load_data("apisrs")
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,71 +4,33 @@ CurrentModule = Survey
 
 # Survey
 
-This package is used to study complex survey data. It aims to provide an efficient computing framework for survey analysis, and be a faster alternative to the `survey` package[^12] ecosystem in R developed by Prof Thomas Lumley[^1].
+This package is used to study complex survey data. It aims to provide an efficient computing framework for survey analysis.
 
 Surveys are a standard tool for empirical research in social and behavioral sciences, and also widely used by governments and businesses alike. In order to get a better representation or more precise estimates, complex surveys use sophisticated sampling techniques like clustering, stratification, unequal probability selection or a combination of these. Computing population estimates from a survey with corresponding standard errors requires several corrections, weights calibrations and adjustments, wherein stems the need for a "survey" package which automatically applies these mathematical techniques.
 
-Several software tools are available to study complex surveys[^10]. The R package is a widely used open-source package. 
+Several software tools are available to study complex surveys[^1]. The [survey package in R](https://cran.r-project.org/web/packages/survey/index.html) is a widely used open-source package. 
 
-## Why a package for survey analysis in Julia?
+Sizes of survey datasets has been growing with advances in computing power and storage, as well as ease of administering surveys online over longer distances and wider geographic areas. The rapidly growing sizes of survey datasets requires an efficient computing framework. This Julia package aims to provide such a framework. 
 
-### Performance with expressivity 
-Sizes of survey datasets has been growing with advances in computing power and storage, as well as ease of administering surveys online over longer distances and wider geographic areas. The rapidly growing sizes of survey datasets requires an efficient computing framework. 
+Presently, summary statistics such as `mean`, `total`, `ratio`, and `quantile` can be estimated for whole of sample as well as subpopulations/domains using this package. Variance estimation for these estimators are performed using Rao-Wu bootstrap[^2]. Visualisations such a scatter plot, histogram and box plot can also be generated. 
 
-While the R package excels in *expressivity*, *performance* was not a key development goal[^13]. Users of this package have waited hours/days in R generating summary statistics (with  standard errors) on really large surveys[^11].
-
-Julia is able to combine the **expressivity** of R with the **speed** of a systems programming language. 
-
-### Development and maintenance
-1. While the R package's performance can be improved by writing functions in C/C++/FORTRAN [^7], a multilanguage package is harder for the community develop and maintain. Julia avoids the two language problem. Statisticians can contribute to a Julia package without worrying about intricate computer engineering challenges introduced by lower level languages. 
-2. Julia packages are built on GitHub. It makes easy for multiple developers to work together on a project. At the same time, it makes it easier for users to file bug reports and issues. Through workflows, GitHub integrates with a variety of tools, making it easier for developers to automate their workflow and manage their projects.  
-
-### Statistical ecosystem
-
-1. The data science ecosystem in Julia excels as it has evolved learning from its competitors in other languages. `DataFrames`[^3] provides an efficient and expressive framework for tabular data manipulation. `Makie` provides a tightly integrated visualisation backend for graphical analysis. 
-2. The combination of expressivity and performance has given rise to many cutting edge work such are probabilistic programming in `Turing`[^4] and automatic differentiation in `Optim`[^6].    
-For these reasons, a survey package in Julia built on this ecosystem can be *better* than those in other languages and also be a platform to implement cutting edge statistical methods.  
-
-### Community interest
-
-There has been interest in a package for survey analysis in the Julia community[^8], and several attempts to create a package, which never materialised[^9]. In the course of development of the package, we received positive feedback and even contributing PRs on the project[^5].
-
-## Highlights
-Current feature highlights include:
-- Data manipulation and analysis are implemented using DataFrames.jl.
-- Summary statistics such as `mean`, `total`, `ratio`, and `quantile` for whole of sample as well as subpopulations/domains.
-- Variance estimation using resampling techniques (current default Rao-Wu bootstrap)
-- Single stage approximation of multistage sampling schemes
-- Common graphical analysis functions using [AlgebraOfGraphics](https://github.com/MakieOrg/AlgebraOfGraphics.jl) backend
-- Inspired by the familiar R [survey](https://r-survey.r-forge.r-project.org/survey/), and related package interface in the R ecosystem.
+The package is built on top of [DataFrames.jl](https://dataframes.juliadata.org/stable/) and all its rich set of features are available for data manipulation. Plots are generated using [AlgebraOfGraphics](https://github.com/MakieOrg/AlgebraOfGraphics.jl). Its features can be accessed via keyword arguments.  
 
 ## Plans
 We plan for efficient implementations of all the methods in R `survey`. Features for future releases will include:
 
 - Variance by Taylor linearization for `SurveyDesign`
-- Support additional replicate weighting algorithms (BRR, Jackknife, other bootstrap flavours) for `ReplicateDesign`
+- Support additional replicate weighting algorithms (BRR, Jackknife, other bootstrap flavors) for `ReplicateDesign`
 - Support for more complex survey designs
 - Post-stratification, raking or calibration, GREG estimation and related methods.
 - Contingency table analysis, support for [CategoricalArrays](https://github.com/JuliaData/CategoricalArrays.jl)
 - Integration with [CRRao.jl](https://github.com/xKDR/CRRao.jl) for regressions, with design based standard errors. 
 - Integration with [GLM.jl](https://github.com/JuliaStats/GLM.jl)
-- Support and speedups with [CategoricalsArrays](https://github.com/JuliaData/CategoricalArrays.jl)
+- Support for [CategoricalsArrays](https://github.com/JuliaData/CategoricalArrays.jl)
 - Association and likelihood ratio tests
 - Support for [imputing missing data](https://stat.ethz.ch/CRAN/web/packages/mitools/index.html)
-- Bayesian surveys
 
 ## References
 
-[^1]: [Thomas Lumley Homepage](https://www.stat.auckland.ac.nz/people/tlum005)
-[^2]: [Makie project](https://docs.makie.org/stable/)
-[^3]: [DataFrames.jl](https://dataframes.juliadata.org/stable/) 
-[^4]: [Turing](https://turing.ml/stable/)
-[^5]: Discussion on discourse posts in [August](https://discourse.julialang.org/t/suggestions-for-the-design-of-survey-jl/86381) and [April](https://discourse.julialang.org/t/pushing-julia-statistics-development/80111) 2022.
-[^6]: [Optim.jl](https://julianlsolvers.github.io/Optim.jl/stable/)
-[^7]: Ben Schneider [blog post](https://www.practicalsignificance.com/posts/making-the-survey-package-run-100x-faster/) on how to use RCpp to make `survey` faster
-[^8]: Julia Discourse posts [here](https://discourse.julialang.org/t/any-package-for-survey-data-analysis/67317) and [here](https://discourse.julialang.org/t/analysis-of-complex-surveys-in-julia/44011) 
-[^9]: [samplics/survey.jl](https://github.com/samplics-org/survey.jl) and [jamanrique/SurveyAnalysis.jl](https://github.com/jamanrique/SurveyAnalysis.jl).
-[^10]: Alan Zaslavsky keeps a comprehensive [list](https://www.hcp.med.harvard.edu/statistics/survey-soft/) of survey analysis software for the ASA Section on Survey Research Methods.
-[^11]: Stack exchange [discussion](https://stackoverflow.com/questions/35210712/methods-in-r-for-large-complex-survey-data-sets) of other people with similar stories.
-[^12]: [R survey package](https://cran.r-project.org/web/packages/survey/index.html)
-[^13]: [Domesticating survey data](https://dicook.github.io/WOMBAT/slides/thomas.pdf)
+[^1]: Alan Zaslavsky keeps a comprehensive [list](https://www.hcp.med.harvard.edu/statistics/survey-soft/) of survey analysis software for the ASA Section on Survey Research Methods.
+[^2]: [Rust, Keith F., and J. N. K. Rao. "Variance estimation for complex surveys using replication techniques." Statistical methods in medical research 5.3 (1996): 283-310.](https://journals.sagepub.com/doi/abs/10.1177/096228029600500305?journalCode=smma)

--- a/docs/src/man/dataframes.md
+++ b/docs/src/man/dataframes.md
@@ -2,7 +2,7 @@
 
 The internal structure of a survey design is build upon
 [`DataFrames`](https://dataframes.juliadata.org/stable/). In fact, the `data`
-argument is the only required argument for the constructor and it must be an
+argument is the only required argument for the constructor, and it must be an
 [`AbstractDataFrame`](https://dataframes.juliadata.org/stable/lib/types/#DataFrames.AbstractDataFrame).
 
 ## Data manipulation
@@ -32,7 +32,7 @@ Five columns were added:
   This column is necessary because when making a [`ReplicateDesign`](@ref), the
   [`bootweights`](@ref) function uses [`groupby`](https://dataframes.juliadata.org/stable/lib/functions/#DataFrames.groupby)
   with a column representing the stratification variable. If there are no strata,
-  there is no such column so it should be added in order to keep `bootweights`
+  there is no such column, so it should be added in order to keep `bootweights`
   general.
 
 - `false_cluster` - only in the case of no clustering
@@ -57,13 +57,3 @@ No column was added for frequency weights because the column passed through the
 `weights` argument is used by other functions, hence there is no need to add a
 new column. If `weights` is not specified, then a column called `_weights` is
 added.
-
-## Why DataFrames
-
-Survey data most of the time, if not always, is structured in a way that is very
-well suited for data frames. The [`DataFrames.jl`](https://dataframes.juliadata.org/stable/)
-package is mature and well maintained and provides a lot of functionality that
-proves useful for using inside functions such as [`bootweights`](@ref) or
-[`mean`](@ref). Mainly, the functions used are
-[`groupby`](https://dataframes.juliadata.org/stable/lib/functions/#DataFrames.groupby)
-and [`combine`](https://dataframes.juliadata.org/stable/lib/functions/#DataFrames.combine).


### PR DESCRIPTION
Now, the package isn't an alternative to the R package. It's independent. 

Remove “Why DataFrames” and “Why Julia”. These can be added in the future or in a blog article. 