### PR TITLE
fixed typo in SurveyDesign docstring

### DIFF
--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -30,11 +30,10 @@ individuals in one cluster are sampled. The clusters are considered disjoint and
 ```jldoctest
 julia> apiclus1 = load_data("apiclus1");
 
-julia> dclus1 = SurveyDesign(apiclus1; clusters=:dnum, strata=:stype, weights=:pw)
+julia> dclus1 = SurveyDesign(apiclus1; clusters=:dnum, weights=:pw)
 SurveyDesign:
 data: 183×43 DataFrame
-strata: stype
-    [H, E, E  …  E]
+strata: none
 cluster: dnum
     [637, 637, 637  …  448]
 popsize: [507.7049, 507.7049, 507.7049  …  507.7049]

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -32,7 +32,7 @@ julia> apiclus1 = load_data("apiclus1");
 
 julia> dclus1 = SurveyDesign(apiclus1; clusters=:dnum, weights=:pw)
 SurveyDesign:
-data: 183×43 DataFrame
+data: 183×44 DataFrame
 strata: none
 cluster: dnum
     [637, 637, 637  …  448]


### PR DESCRIPTION
Removed `stype` argument, as `apiclus1` is not stratified.
Checked all files in the `src` folder, they did not contain this mistake.
Closes issue #282 