### PR TITLE
Speed-up in `bootweights` by using a function barrier

### DIFF
--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -30,6 +30,7 @@ function bootweights(design::SurveyDesign; replicates = 4000, rng = MersenneTwis
         cluster_sorted = sort(substrata, design.cluster)
         cluster_sorted_designcluster = cluster_sorted[!, design.cluster]
         cluster_weights = cluster_sorted[!, design.weights]
+        # Perform the inner loop in a type-stable function to improve runtime.
         _bootweights_cluster_sorted!(cluster_sorted, cluster_weights,
             cluster_sorted_designcluster, replicates, rng)
         substrata_dfs[h] = cluster_sorted


### PR DESCRIPTION
Separating out the type-unstable and the type-stable parts leads to a moderate speed-up and a slight reduction in allocation. Using the example from the docstring of `bootweights` on the main branch, we obtain:
```julia
julia> using Random, Survey, BenchmarkTools

julia> apiclus1 = load_data("apiclus1");

julia> dclus1 = SurveyDesign(apiclus1; clusters = :dnum, popsize=:fpc);

julia> @btime bootweights($dclus1; replicates=1000, rng=MersenneTwister(111));
  9.535 ms (49257 allocations: 8.93 MiB)
```
This PR
```julia
julia> @btime bootweights($dclus1; replicates=1000, rng=MersenneTwister(111));
  8.235 ms (44213 allocations: 8.89 MiB)
```
A speedup of `13%`