### PR TITLE
New data structures to support multiple replicate methods.

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -17,7 +17,7 @@ JackknifeReplicates
 load_data
 bootweights
 jackknifeweights
-jackknife_variance
+variance
 mean
 total
 quantile

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -12,6 +12,8 @@ Private = false
 AbstractSurveyDesign
 SurveyDesign
 ReplicateDesign
+BootstrapReplicates
+JackknifeReplicates
 load_data
 bootweights
 jackknifeweights

--- a/src/Survey.jl
+++ b/src/Survey.jl
@@ -37,6 +37,6 @@ export hist, sturges, freedman_diaconis
 export boxplot
 export bootweights
 export ratio
-export jackknifeweights, jackknife_variance
+export jackknifeweights, variance
 
 end

--- a/src/Survey.jl
+++ b/src/Survey.jl
@@ -15,6 +15,7 @@ using Missings
 
 include("SurveyDesign.jl")
 include("bootstrap.jl")
+include("jackknife.jl")
 include("mean.jl")
 include("quantile.jl")
 include("total.jl")
@@ -25,7 +26,6 @@ include("boxplot.jl")
 include("show.jl")
 include("ratio.jl")
 include("by.jl")
-include("jackknife.jl")
 
 export load_data
 export AbstractSurveyDesign, SurveyDesign, ReplicateDesign

--- a/src/Survey.jl
+++ b/src/Survey.jl
@@ -29,6 +29,7 @@ include("jackknife.jl")
 
 export load_data
 export AbstractSurveyDesign, SurveyDesign, ReplicateDesign
+export BootstrapReplicates, JackknifeReplicates
 export dim, colnames, dimnames
 export mean, total, quantile
 export plot

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -289,7 +289,7 @@ struct ReplicateDesign{ReplicateType} <: AbstractSurveyDesign
         type::String,
         replicates::UInt,
         replicate_weights::Vector{Symbol},
-    ) where {ReplicateType}
+    ) where {ReplicateType <: InferenceMethod}
         new{ReplicateType}(data, cluster, popsize, sampsize, strata, weights, allprobs,
            pps, type, replicates, replicate_weights, ReplicateType(replicates))
     end
@@ -302,7 +302,7 @@ struct ReplicateDesign{ReplicateType} <: AbstractSurveyDesign
         strata::Union{Nothing,Symbol} = nothing,
         popsize::Union{Nothing,Symbol} = nothing,
         weights::Union{Nothing,Symbol} = nothing
-    ) where {ReplicateType}
+    ) where {ReplicateType <: InferenceMethod}
         # rename the replicate weights if needed
         rename!(data, [replicate_weights[index] => "replicate_"*string(index) for index in 1:length(replicate_weights)])
 
@@ -338,7 +338,7 @@ struct ReplicateDesign{ReplicateType} <: AbstractSurveyDesign
         strata::Union{Nothing,Symbol} = nothing,
         popsize::Union{Nothing,Symbol} = nothing,
         weights::Union{Nothing,Symbol} = nothing
-    ) where {ReplicateType} =
+    ) where {ReplicateType <: InferenceMethod} =
         ReplicateDesign{ReplicateType}(
             data,
             Symbol.(names(data)[replicate_weights]);
@@ -356,7 +356,7 @@ struct ReplicateDesign{ReplicateType} <: AbstractSurveyDesign
         strata::Union{Nothing,Symbol} = nothing,
         popsize::Union{Nothing,Symbol} = nothing,
         weights::Union{Nothing,Symbol} = nothing
-    ) where {ReplicateType} =
+    ) where {ReplicateType <: InferenceMethod} =
         ReplicateDesign{ReplicateType}(
             data,
             Symbol.(names(data)[findall(name -> occursin(replicate_weights, name), names(data))]);

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -164,7 +164,7 @@ ReplicateDesign{ReplicateType}(
     strata::Union{Nothing,Symbol} = nothing,
     popsize::Union{Nothing,Symbol} = nothing,
     weights::Union{Nothing,Symbol} = nothing
-) where {ReplicateType <: InferenceType}
+) where {ReplicateType <: InferenceMethod}
 
 ReplicateDesign{ReplicateType}(
     data::AbstractDataFrame,
@@ -173,7 +173,7 @@ ReplicateDesign{ReplicateType}(
     strata::Union{Nothing,Symbol} = nothing,
     popsize::Union{Nothing,Symbol} = nothing,
     weights::Union{Nothing,Symbol} = nothing
-) where {ReplicateType <: InferenceType}
+) where {ReplicateType <: InferenceMethod}
 
 ReplicateDesign{ReplicateType}(
     data::AbstractDataFrame,
@@ -182,7 +182,7 @@ ReplicateDesign{ReplicateType}(
     strata::Union{Nothing,Symbol} = nothing,
     popsize::Union{Nothing,Symbol} = nothing,
     weights::Union{Nothing,Symbol} = nothing
-) where {ReplicateType <: InferenceType}
+) where {ReplicateType <: InferenceMethod}
 ```
 
 # Arguments

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -123,12 +123,27 @@ struct SurveyDesign <: AbstractSurveyDesign
     end
 end
 
+"""
+    InferenceMethod
+
+Abstract type for inference methods.
+"""
 abstract type InferenceMethod end
 
+"""
+    BootstrapReplicates <: InferenceMethod
+
+Type for the bootstrap replicates method. For more details, see [`bootweights`](@ref).
+"""
 struct BootstrapReplicates <: InferenceMethod
     replicates::UInt
 end
 
+"""
+    JackknifeReplicates <: InferenceMethod
+
+Type for the Jackknife replicates method. For more details, see [`jackknifeweights`](@ref).
+"""
 struct JackknifeReplicates <: InferenceMethod
     replicates::UInt
 end

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -123,6 +123,15 @@ struct SurveyDesign <: AbstractSurveyDesign
     end
 end
 
+
+struct BootstrapReplicates
+    replicates::UInt
+end
+
+struct JackknifeReplicates
+    replicates::UInt
+end
+
 """
     ReplicateDesign <: AbstractSurveyDesign
 

--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -136,43 +136,43 @@ end
 """
     ReplicateDesign <: AbstractSurveyDesign
 
-Survey design obtained by replicating an original design using [`bootweights`](@ref). If
-replicate weights are available, then they can be used to directly create a `ReplicateDesign`.
+Survey design obtained by replicating an original design using an inference method like [`bootweights`](@ref) or [`jackknifeweights`](@ref). If
+replicate weights are available, then they can be used to directly create a `ReplicateDesign` object.
 
 # Constructors
 
 ```julia
-ReplicateDesign(
+ReplicateDesign{ReplicateType}(
     data::AbstractDataFrame,
     replicate_weights::Vector{Symbol};
     clusters::Union{Nothing,Symbol,Vector{Symbol}} = nothing,
     strata::Union{Nothing,Symbol} = nothing,
     popsize::Union{Nothing,Symbol} = nothing,
     weights::Union{Nothing,Symbol} = nothing
-)
+) where {ReplicateType <: InferenceType}
 
-ReplicateDesign(
+ReplicateDesign{ReplicateType}(
     data::AbstractDataFrame,
     replicate_weights::UnitIndex{Int};
     clusters::Union{Nothing,Symbol,Vector{Symbol}} = nothing,
     strata::Union{Nothing,Symbol} = nothing,
     popsize::Union{Nothing,Symbol} = nothing,
     weights::Union{Nothing,Symbol} = nothing
-)
+) where {ReplicateType <: InferenceType}
 
-ReplicateDesign(
+ReplicateDesign{ReplicateType}(
     data::AbstractDataFrame,
     replicate_weights::Regex;
     clusters::Union{Nothing,Symbol,Vector{Symbol}} = nothing,
     strata::Union{Nothing,Symbol} = nothing,
     popsize::Union{Nothing,Symbol} = nothing,
     weights::Union{Nothing,Symbol} = nothing
-)
+) where {ReplicateType <: InferenceType}
 ```
 
 # Arguments
 
-The constructor has the same arguments as [`SurveyDesign`](@ref). The only additional argument is `replicate_weights`, which can
+`ReplicateType` must be one of the supported inference types; currently the package supports [`BootstrapReplicates`](@ref) and [`JackknifeReplicates`](@ref). The constructor has the same arguments as [`SurveyDesign`](@ref). The only additional argument is `replicate_weights`, which can
 be of one of the following types.
 
 - `Vector{Symbol}`: In this case, each `Symbol` in the vector should represent a column of `data` containing the replicate weights.
@@ -183,7 +183,7 @@ All the columns containing the replicate weights will be renamed to the form `re
 
 # Examples
 
-Here is an example where the [`bootweights`](@ref) function is used to create a `ReplicateDesign`.
+Here is an example where the [`bootweights`](@ref) function is used to create a `ReplicateDesign{BootstrapReplicates}`.
 
 ```jldoctest replicate-design; setup = :(using Survey, CSV, DataFrames)
 julia> apistrat = load_data("apistrat");
@@ -191,7 +191,7 @@ julia> apistrat = load_data("apistrat");
 julia> dstrat = SurveyDesign(apistrat; strata=:stype, weights=:pw);
 
 julia> bootstrat = bootweights(dstrat; replicates=1000)     # creating a ReplicateDesign using bootweights
-ReplicateDesign:
+ReplicateDesign{BootstrapReplicates}:
 data: 200×1044 DataFrame
 strata: stype
     [E, E, E  …  H]
@@ -220,8 +220,8 @@ julia> CSV.write("apistrat_withreplicates.csv", bootstrat.data);
 We can now pass the replicate weights directly to the `ReplicateDesign` constructor, either as a `Vector{Symbol}`, a `UnitRange` or a `Regex`.
 
 ```jldoctest replicate-design
-julia> bootstrat_direct = ReplicateDesign(CSV.read("apistrat_withreplicates.csv", DataFrame), [Symbol("r_"*string(replicate)) for replicate in 1:1000]; strata=:stype, weights=:pw)
-ReplicateDesign:
+julia> bootstrat_direct = ReplicateDesign{BootstrapReplicates}(CSV.read("apistrat_withreplicates.csv", DataFrame), [Symbol("r_"*string(replicate)) for replicate in 1:1000]; strata=:stype, weights=:pw)
+ReplicateDesign{BootstrapReplicates}:
 data: 200×1044 DataFrame
 strata: stype
     [E, E, E  …  H]
@@ -233,8 +233,8 @@ allprobs: [0.0226, 0.0226, 0.0226  …  0.0662]
 type: bootstrap
 replicates: 1000
 
-julia> bootstrat_unitrange = ReplicateDesign(CSV.read("apistrat_withreplicates.csv", DataFrame), UnitRange(45:1044);strata=:stype, weights=:pw)
-ReplicateDesign:
+julia> bootstrat_unitrange = ReplicateDesign{BootstrapReplicates}(CSV.read("apistrat_withreplicates.csv", DataFrame), UnitRange(45:1044);strata=:stype, weights=:pw)
+ReplicateDesign{BootstrapReplicates}:
 data: 200×1044 DataFrame
 strata: stype
     [E, E, E  …  H]
@@ -246,8 +246,8 @@ allprobs: [0.0226, 0.0226, 0.0226  …  0.0662]
 type: bootstrap
 replicates: 1000
 
-julia> bootstrat_regex = ReplicateDesign(CSV.read("apistrat_withreplicates.csv", DataFrame), r"r_\\d";strata=:stype, weights=:pw)
-ReplicateDesign:
+julia> bootstrat_regex = ReplicateDesign{BootstrapReplicates}(CSV.read("apistrat_withreplicates.csv", DataFrame), r"r_\\d";strata=:stype, weights=:pw)
+ReplicateDesign{BootstrapReplicates}:
 data: 200×1044 DataFrame
 strata: stype
     [E, E, E  …  H]

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -63,9 +63,9 @@ Use replicate weights to compute the standard error of the estimated mean using 
 \\hat{V}(\\hat{\\theta}) = \\dfrac{1}{R}\\sum_{i = 1}^R(\\theta_i - \\hat{\\theta})^2
 ```
 
-where above ``R`` is the number of replicate weights, ``\\theta_i`` is the estimated mean using the ``i``th set of replicate weights, and ``\\hat{\\theta}`` is the estimated mean using the original weights.
+where above ``R`` is the number of replicate weights, ``\\theta_i`` is the estimator computed using the ``i``th set of replicate weights, and ``\\hat{\\theta}`` is the estimator computed using the original weights.
 
-```jldoctest;
+```jldoctest
 julia> using Survey, StatsBase;
 
 julia> apiclus1 = load_data("apiclus1");
@@ -83,6 +83,7 @@ julia> variance(:api00, weightedmean, bclus1)
 ─────┼────────────────────
    1 │   644.169  23.4107
 
+```
 """
 function variance(x::Symbol, func::Function, design::ReplicateDesign{BootstrapReplicates})
     θ̂ = func(design.data[!, x], design.data[!, design.weights])

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -78,11 +78,11 @@ julia> weightedmean(x, y) = mean(x, weights(y));
 
 julia> variance(:api00, weightedmean, bclus1)
 1×2 DataFrame
- Row │ mean     SE
-     │ Float64  Float64
-─────┼──────────────────
-   1 │ 644.169  23.4107
-```
+ Row │ estimator  SE
+     │ Float64    Float64
+─────┼────────────────────
+   1 │   644.169  23.4107
+
 """
 function variance(x::Symbol, func::Function, design::ReplicateDesign{BootstrapReplicates})
     θ̂ = func(design.data[!, x], design.data[!, design.weights])
@@ -91,7 +91,7 @@ function variance(x::Symbol, func::Function, design::ReplicateDesign{BootstrapRe
         i = 1:design.replicates
     ]
     variance = sum((θ̂t .- θ̂) .^ 2) / design.replicates
-    return DataFrame(mean = θ̂, SE = sqrt(variance))
+    return DataFrame(estimator = θ̂, SE = sqrt(variance))
 end
 
 function _bootweights_cluster_sorted!(cluster_sorted,

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -1,5 +1,5 @@
 """
-Use bootweights to create replicate weights using Rao-Wu bootstrap. The function accepts a `SurveyDesign` and returns a `ReplicateDesign` which has additional columns for replicate weights. 
+Use bootweights to create replicate weights using Rao-Wu bootstrap. The function accepts a `SurveyDesign` and returns a `ReplicateDesign{BootstrapReplicates}` which has additional columns for replicate weights.
 
 ```jldoctest
 julia> using Random
@@ -37,7 +37,7 @@ function bootweights(design::SurveyDesign; replicates = 4000, rng = MersenneTwis
         substrata_dfs[h] = cluster_sorted
     end
     df = reduce(vcat, substrata_dfs)
-    return ReplicateDesign(
+    return ReplicateDesign{BootstrapReplicates}(
         df,
         design.cluster,
         design.popsize,
@@ -48,7 +48,7 @@ function bootweights(design::SurveyDesign; replicates = 4000, rng = MersenneTwis
         design.pps,
         "bootstrap",
         UInt(replicates),
-        [Symbol("replicate_"*string(replicate)) for replicate in 1:replicates]
+        [Symbol("replicate_"*string(replicate)) for replicate in 1:replicates],
     )
 end
 

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -9,7 +9,7 @@ julia> apiclus1 = load_data("apiclus1");
 julia> dclus1 = SurveyDesign(apiclus1; clusters = :dnum, popsize=:fpc);
 
 julia> bootweights(dclus1; replicates=1000, rng=MersenneTwister(111)) # choose a seed for deterministic results
-ReplicateDesign:
+ReplicateDesign{BootstrapReplicates}:
 data: 183×1044 DataFrame
 strata: none
 cluster: dnum
@@ -20,6 +20,7 @@ weights: [50.4667, 50.4667, 50.4667  …  50.4667]
 allprobs: [0.0198, 0.0198, 0.0198  …  0.0198]
 type: bootstrap
 replicates: 1000
+
 ```
 """
 function bootweights(design::SurveyDesign; replicates = 4000, rng = MersenneTwister(1234))

--- a/src/jackknife.jl
+++ b/src/jackknife.jl
@@ -83,7 +83,7 @@ function jackknifeweights(design::SurveyDesign)
 end
 
 """
-    jackknife_variance(x::Symbol, func::Function, design::ReplicateDesign{JackknifeReplicates})
+    variance(x::Symbol, func::Function, design::ReplicateDesign{JackknifeReplicates})
 
 Compute variance of column `x` for the given `func` using the Jackknife method. The formula to compute this variance is the following.
 
@@ -116,7 +116,7 @@ replicates: 200
 
 julia> weightedmean(x, y) = mean(x, weights(y));
 
-julia> jackknife_variance(:api00, weightedmean, rstrat)
+julia> variance(:api00, weightedmean, rstrat)
 1×2 DataFrame
  Row │ estimator  SE
      │ Float64    Float64
@@ -127,7 +127,7 @@ julia> jackknife_variance(:api00, weightedmean, rstrat)
 # Reference
 pg 380-382, Section 9.3.2 Jackknife - Sharon Lohr, Sampling Design and Analysis (2010)
 """
-function jackknife_variance(x::Symbol, func::Function, design::ReplicateDesign{JackknifeReplicates})
+function variance(x::Symbol, func::Function, design::ReplicateDesign{JackknifeReplicates})
     df = design.data
     # sort!(df, [design.strata, design.cluster])
     stratified_gdf = groupby(df, design.strata)

--- a/src/jackknife.jl
+++ b/src/jackknife.jl
@@ -67,7 +67,7 @@ function jackknifeweights(design::SurveyDesign)
         end
     end
 
-    return ReplicateDesign(
+    return ReplicateDesign{JackknifeReplicates}(
         df,
         design.cluster,
         design.popsize,

--- a/src/jackknife.jl
+++ b/src/jackknife.jl
@@ -22,7 +22,7 @@ julia> apistrat = load_data("apistrat");
 julia> dstrat = SurveyDesign(apistrat; strata=:stype, weights=:pw);
 
 julia> rstrat = jackknifeweights(dstrat)
-ReplicateDesign:
+ReplicateDesign{JackknifeReplicates}:
 data: 200×244 DataFrame
 strata: stype
     [E, E, E  …  M]
@@ -83,7 +83,7 @@ function jackknifeweights(design::SurveyDesign)
 end
 
 """
-    jackknife_variance(x::Symbol, func::Function, design::ReplicateDesign)
+    jackknife_variance(x::Symbol, func::Function, design::ReplicateDesign{JackknifeReplicates})
 
 Compute variance of column `x` for the given `func` using the Jackknife method. The formula to compute this variance is the following.
 
@@ -102,7 +102,7 @@ julia> apistrat = load_data("apistrat");
 julia> dstrat = SurveyDesign(apistrat; strata=:stype, weights=:pw);
 
 julia> rstrat = jackknifeweights(dstrat)
-ReplicateDesign:
+ReplicateDesign{JackknifeReplicates}:
 data: 200×244 DataFrame
 strata: stype
     [E, E, E  …  M]
@@ -127,7 +127,7 @@ julia> jackknife_variance(:api00, weightedmean, rstrat)
 # Reference
 pg 380-382, Section 9.3.2 Jackknife - Sharon Lohr, Sampling Design and Analysis (2010)
 """
-function jackknife_variance(x::Symbol, func::Function, design::ReplicateDesign)
+function jackknife_variance(x::Symbol, func::Function, design::ReplicateDesign{JackknifeReplicates})
     df = design.data
     # sort!(df, [design.strata, design.cluster])
     stratified_gdf = groupby(df, design.strata)

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -57,7 +57,7 @@ function mean(x::Symbol, design::ReplicateDesign)
     # Jackknife integration
     elseif design.type == "jackknife"
         weightedmean(x, y) = mean(x, weights(y))
-        return variance(x, weightedmean, design)
+        return Survey.variance(x, weightedmean, design)
     end
 end
 

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -50,7 +50,9 @@ julia> mean(:api00, bclus1)
 """
 function mean(x::Symbol, design::ReplicateDesign)
 	weightedmean(x, y) = mean(x, weights(y))
-	Survey.variance(x, weightedmean, design)
+	df = Survey.variance(x, weightedmean, design)
+    rename!(df, :estimator => :mean)
+    return df
 end
 
 """

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -57,7 +57,7 @@ function mean(x::Symbol, design::ReplicateDesign)
     # Jackknife integration
     elseif design.type == "jackknife"
         weightedmean(x, y) = mean(x, weights(y))
-        return jackknife_variance(x, weightedmean, design)
+        return variance(x, weightedmean, design)
     end
 end
 

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -31,37 +31,6 @@ function mean(x::Symbol, design::SurveyDesign)
 end
 
 """
-
-Use replicate weights to compute the standard error of the estimated mean. 
-
-```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
-julia> bclus1 = dclus1 |> bootweights;
-
-julia> mean(:api00, bclus1)
-1×2 DataFrame
- Row │ mean     SE
-     │ Float64  Float64
-─────┼──────────────────
-   1 │ 644.169  23.4107
-```
-"""
-function mean(x::Symbol, design::ReplicateDesign)
-    if design.type == "bootstrap"
-        θ̂ = mean(design.data[!, x], weights(design.data[!, design.weights]))
-        θ̂t = [
-            mean(design.data[!, x], weights(design.data[!, "replicate_"*string(i)])) for
-            i = 1:design.replicates
-        ]
-        variance = sum((θ̂t .- θ̂) .^ 2) / design.replicates
-        return DataFrame(mean = θ̂, SE = sqrt(variance))
-    # Jackknife integration
-    elseif design.type == "jackknife"
-        weightedmean(x, y) = mean(x, weights(y))
-        return Survey.variance(x, weightedmean, design)
-    end
-end
-
-"""
 Estimate the mean of a list of variables.
 
 ```jldoctest meanlabel; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); bclus1 = dclus1 |> bootweights)

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -31,6 +31,29 @@ function mean(x::Symbol, design::SurveyDesign)
 end
 
 """
+	mean(x::Symbol, design::ReplicateDesign)
+
+Use replicate weights to compute the standard error of the estimated mean.
+
+# Examples
+
+```jldoctest; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw))
+julia> bclus1 = dclus1 |> bootweights;
+
+julia> mean(:api00, bclus1)
+1×2 DataFrame
+ Row │ mean     SE
+     │ Float64  Float64
+─────┼──────────────────
+   1 │ 644.169  23.4107
+```
+"""
+function mean(x::Symbol, design::ReplicateDesign)
+	weightedmean(x, y) = mean(x, weights(y))
+	Survey.variance(x, weightedmean, design)
+end
+
+"""
 Estimate the mean of a list of variables.
 
 ```jldoctest meanlabel; setup = :(apiclus1 = load_data("apiclus1"); dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw); bclus1 = dclus1 |> bootweights)

--- a/src/total.jl
+++ b/src/total.jl
@@ -36,13 +36,10 @@ julia> total(:api00, bclus1)
 ```
 """
 function total(x::Symbol, design::ReplicateDesign)
-    X = wsum(design.data[!, x], weights(design.data[!, design.weights]))
-    Xt = [
-        wsum(design.data[!, x], weights(design.data[!, "replicate_"*string(i)])) for
-        i = 1:design.replicates
-    ]
-    variance = sum((Xt .- X) .^ 2) / design.replicates
-    DataFrame(total = X, SE = sqrt(variance))
+    total_func(x, y) = wsum(x, weights(y))
+    df = variance(x, total_func, design)
+    rename!(df, :estimator => :total)
+    return df
 end
 
 """

--- a/test/jackknife.jl
+++ b/test/jackknife.jl
@@ -19,9 +19,9 @@
     
     # Tests using for NHANES
     mean_nhanes_jk = mean([:seq1, :seq2],dnhanes_jk)
-    @test mean_nhanes_jk.estimator[1] ≈ 21393.96 atol = 1e-3
+    @test mean_nhanes_jk.mean[1] ≈ 21393.96 atol = 1e-3
     @test mean_nhanes_jk.SE[1] ≈ 143.371 atol = 1e-3 # R is slightly diff in 2nd decimal place
-    @test mean_nhanes_jk.estimator[2] ≈ 38508.328 atol = 1e-3
+    @test mean_nhanes_jk.mean[2] ≈ 38508.328 atol = 1e-3
     @test mean_nhanes_jk.SE[2] ≈ 258.068 atol = 1e-3 # R is slightly diff in 2nd decimal place
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,18 +13,18 @@ apisrs = load_data("apisrs") # Load API dataset
 srs = SurveyDesign(apisrs, weights = :pw)
 unitrange = UnitRange((length(names(apisrs)) + 1):(TOTAL_REPLICATES + length(names(apisrs))))
 bsrs = srs |> bootweights # Create replicate design
-bsrs_direct = ReplicateDesign(bsrs.data, REPLICATES_VECTOR, weights = :pw)  # using ReplicateDesign constructor
-bsrs_unitrange = ReplicateDesign(bsrs.data, unitrange, weights = :pw)  # using ReplicateDesign constructor
-bsrs_regex = ReplicateDesign(bsrs.data, REPLICATES_REGEX, weights = :pw)  # using ReplicateDesign constructor
+bsrs_direct = ReplicateDesign{BootstrapReplicates}(bsrs.data, REPLICATES_VECTOR, weights = :pw)  # using ReplicateDesign constructor
+bsrs_unitrange = ReplicateDesign{BootstrapReplicates}(bsrs.data, unitrange, weights = :pw)  # using ReplicateDesign constructor
+bsrs_regex = ReplicateDesign{BootstrapReplicates}(bsrs.data, REPLICATES_REGEX, weights = :pw)  # using ReplicateDesign constructor
 
 # Stratified sample
 apistrat = load_data("apistrat") # Load API dataset
 dstrat = SurveyDesign(apistrat, strata = :stype, weights = :pw) # Create SurveyDesign
 unitrange = UnitRange((length(names(apistrat)) + 1):(TOTAL_REPLICATES + length(names(apistrat))))
 bstrat = dstrat |> bootweights # Create replicate design
-bstrat_direct = ReplicateDesign(bstrat.data, REPLICATES_VECTOR, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
-bstrat_unitrange = ReplicateDesign(bstrat.data, unitrange, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
-bstrat_regex = ReplicateDesign(bstrat.data, REPLICATES_REGEX, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
+bstrat_direct = ReplicateDesign{BootstrapReplicates}(bstrat.data, REPLICATES_VECTOR, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
+bstrat_unitrange = ReplicateDesign{BootstrapReplicates}(bstrat.data, unitrange, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
+bstrat_regex = ReplicateDesign{BootstrapReplicates}(bstrat.data, REPLICATES_REGEX, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
 
 # One-stage cluster sample
 apiclus1 = load_data("apiclus1") # Load API dataset
@@ -32,9 +32,9 @@ apiclus1[!, :pw] = fill(757 / 15, (size(apiclus1, 1),)) # Correct api mistake fo
 dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw) # Create SurveyDesign
 unitrange = UnitRange((length(names(apiclus1)) + 1):(TOTAL_REPLICATES + length(names(apiclus1))))
 dclus1_boot = dclus1 |> bootweights # Create replicate design
-dclus1_boot_direct = ReplicateDesign(dclus1_boot.data, REPLICATES_VECTOR, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
-dclus1_boot_unitrange = ReplicateDesign(dclus1_boot.data, unitrange, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
-dclus1_boot_regex = ReplicateDesign(dclus1_boot.data, REPLICATES_REGEX, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
+dclus1_boot_direct = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, REPLICATES_VECTOR, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
+dclus1_boot_unitrange = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, unitrange, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
+dclus1_boot_regex = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, REPLICATES_REGEX, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
 
 # Two-stage cluster sample
 apiclus2 = load_data("apiclus2") # Load API dataset

--- a/test/show.jl
+++ b/test/show.jl
@@ -15,7 +15,7 @@
     @test str == refstr
 
     refstrb = """
-    ReplicateDesign:
+    ReplicateDesign{BootstrapReplicates}:
     data: 200×4045 DataFrame
     strata: none
     cluster: none
@@ -50,7 +50,7 @@ end
     @test str == refstr
 
     refstrb = """
-    ReplicateDesign:
+    ReplicateDesign{BootstrapReplicates}:
     data: 200×4044 DataFrame
     strata: stype
         [E, E, E  …  H]
@@ -86,7 +86,7 @@ end
     @test str == refstr
 
     refstrb = """
-    ReplicateDesign:
+    ReplicateDesign{BootstrapReplicates}:
     data: 183×4044 DataFrame
     strata: none
     cluster: dnum


### PR DESCRIPTION
This PR introduces a "replicate type" for every `ReplicateDesign` object. The purpose is mainly to help with multiple dispatch on difference replicate methods.

We have introduced a new abstract type called `InferenceMethod`, which will be a supertype for all inference types. For now, the package only supports two inference methods, which we've encoded by the `BootstrapReplicates` and `JackknifeReplicates` structs.

Relevant changes have been made to the `ReplicateDesign` struct to incorporate the new structure.

Also, the `mean`, `total` and `quantile` functions have now been written using the generic `variance` function. Since `ratio` takes two columns as it's arguments, it can't be implemented using `variance` as of now (see #295 ).

Closes #261 