### PR TITLE
Refactor SurveyDesign constructor to SurveyDesign!

### DIFF
--- a/src/SurveyDesign.jl
+++ b/src/SurveyDesign.jl
@@ -52,7 +52,7 @@ struct SurveyDesign <: AbstractSurveyDesign
     allprobs::Symbol # Right now only singlestage approx supported
     pps::Bool # TODO functionality
     # Single stage clusters sample, like apiclus1
-    function SurveyDesign(
+    function SurveyDesign!(
         data::AbstractDataFrame;
         clusters::Union{Nothing,Symbol,Vector{Symbol}} = nothing,
         strata::Union{Nothing,Symbol} = nothing,
@@ -323,7 +323,7 @@ struct ReplicateDesign{ReplicateType} <: AbstractSurveyDesign
         rename!(data, [replicate_weights[index] => "replicate_"*string(index) for index in 1:length(replicate_weights)])
 
         # call the SurveyDesign constructor
-        base_design = SurveyDesign(
+        base_design = SurveyDesign!(
                         data;
                         clusters=clusters,
                         strata=strata,

--- a/src/by.jl
+++ b/src/by.jl
@@ -1,5 +1,5 @@
 function subset(group, design::SurveyDesign)
-    return SurveyDesign(DataFrame(group);clusters = design.cluster, strata = design.strata, popsize = design.popsize, weights = design.weights)   
+    return SurveyDesign!(DataFrame(group);clusters = design.cluster, strata = design.strata, popsize = design.popsize, weights = design.weights)   
 end 
 
 function subset(group, design::ReplicateDesign)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ REPLICATES_REGEX = r"r*_\d"
 
 # Simple random sample
 apisrs = load_data("apisrs") # Load API dataset
-srs = SurveyDesign(apisrs, weights=:pw)
+srs = SurveyDesign!(apisrs, weights=:pw)
 unitrange = UnitRange((length(names(apisrs))+1):(TOTAL_REPLICATES+length(names(apisrs))))
 bsrs = srs |> bootweights # Create bootstrap replicate design
 jsrs = srs |> jackknifeweights # Create jackknife replicate design
@@ -22,7 +22,7 @@ bsrs_regex = ReplicateDesign{BootstrapReplicates}(bsrs.data, REPLICATES_REGEX, w
 
 # Stratified sample
 apistrat = load_data("apistrat") # Load API dataset
-dstrat = SurveyDesign(apistrat, strata=:stype, weights=:pw) # Create SurveyDesign
+dstrat = SurveyDesign!(apistrat, strata=:stype, weights=:pw) # Create SurveyDesign
 unitrange = UnitRange((length(names(apistrat))+1):(TOTAL_REPLICATES+length(names(apistrat))))
 bstrat = dstrat |> bootweights # Create replicate design
 bstrat_direct = ReplicateDesign{BootstrapReplicates}(bstrat.data, REPLICATES_VECTOR, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
@@ -32,7 +32,7 @@ bstrat_regex = ReplicateDesign{BootstrapReplicates}(bstrat.data, REPLICATES_REGE
 # One-stage cluster sample
 apiclus1 = load_data("apiclus1") # Load API dataset
 apiclus1[!, :pw] = fill(757 / 15, (size(apiclus1, 1),)) # Correct api mistake for pw column
-dclus1 = SurveyDesign(apiclus1; clusters=:dnum, weights=:pw) # Create SurveyDesign
+dclus1 = SurveyDesign!(apiclus1; clusters=:dnum, weights=:pw) # Create SurveyDesign
 unitrange = UnitRange((length(names(apiclus1))+1):(TOTAL_REPLICATES+length(names(apiclus1))))
 dclus1_boot = dclus1 |> bootweights # Create replicate design
 dclus1_boot_direct = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, REPLICATES_VECTOR, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
@@ -41,14 +41,14 @@ dclus1_boot_regex = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, REPLI
 
 # Two-stage cluster sample
 apiclus2 = load_data("apiclus2") # Load API dataset
-dclus2 = SurveyDesign(apiclus2; clusters=:dnum, weights=:pw) # Create SurveyDesign
+dclus2 = SurveyDesign!(apiclus2; clusters=:dnum, weights=:pw) # Create SurveyDesign
 dclus2_boot = dclus2 |> bootweights # Create replicate design
 
 # NHANES
 nhanes = load_data("nhanes")
 nhanes.seq1 = collect(1.0:5.0:42955.0)
 nhanes.seq2 = collect(1.0:9.0:77319.0) # [9k for k in 0:8590.0]
-dnhanes = SurveyDesign(nhanes; clusters=:SDMVPSU, strata=:SDMVSTRA, weights=:WTMEC2YR)
+dnhanes = SurveyDesign!(nhanes; clusters=:SDMVPSU, strata=:SDMVSTRA, weights=:WTMEC2YR)
 dnhanes_boot = dnhanes |> bootweights
 
 @testset "Survey.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ REPLICATES_REGEX = r"r*_\d"
 
 # Simple random sample
 apisrs = load_data("apisrs") # Load API dataset
-srs = SurveyDesign!(apisrs, weights=:pw)
+srs = SurveyDesign(apisrs, weights=:pw)
 unitrange = UnitRange((length(names(apisrs))+1):(TOTAL_REPLICATES+length(names(apisrs))))
 bsrs = srs |> bootweights # Create bootstrap replicate design
 jsrs = srs |> jackknifeweights # Create jackknife replicate design
@@ -22,7 +22,7 @@ bsrs_regex = ReplicateDesign{BootstrapReplicates}(bsrs.data, REPLICATES_REGEX, w
 
 # Stratified sample
 apistrat = load_data("apistrat") # Load API dataset
-dstrat = SurveyDesign!(apistrat, strata=:stype, weights=:pw) # Create SurveyDesign
+dstrat = SurveyDesign(apistrat, strata=:stype, weights=:pw) # Create SurveyDesign
 unitrange = UnitRange((length(names(apistrat))+1):(TOTAL_REPLICATES+length(names(apistrat))))
 bstrat = dstrat |> bootweights # Create replicate design
 bstrat_direct = ReplicateDesign{BootstrapReplicates}(bstrat.data, REPLICATES_VECTOR, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
@@ -32,7 +32,7 @@ bstrat_regex = ReplicateDesign{BootstrapReplicates}(bstrat.data, REPLICATES_REGE
 # One-stage cluster sample
 apiclus1 = load_data("apiclus1") # Load API dataset
 apiclus1[!, :pw] = fill(757 / 15, (size(apiclus1, 1),)) # Correct api mistake for pw column
-dclus1 = SurveyDesign!(apiclus1; clusters=:dnum, weights=:pw) # Create SurveyDesign
+dclus1 = SurveyDesign(apiclus1; clusters=:dnum, weights=:pw) # Create SurveyDesign
 unitrange = UnitRange((length(names(apiclus1))+1):(TOTAL_REPLICATES+length(names(apiclus1))))
 dclus1_boot = dclus1 |> bootweights # Create replicate design
 dclus1_boot_direct = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, REPLICATES_VECTOR, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
@@ -41,14 +41,14 @@ dclus1_boot_regex = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, REPLI
 
 # Two-stage cluster sample
 apiclus2 = load_data("apiclus2") # Load API dataset
-dclus2 = SurveyDesign!(apiclus2; clusters=:dnum, weights=:pw) # Create SurveyDesign
+dclus2 = SurveyDesign(apiclus2; clusters=:dnum, weights=:pw) # Create SurveyDesign
 dclus2_boot = dclus2 |> bootweights # Create replicate design
 
 # NHANES
 nhanes = load_data("nhanes")
 nhanes.seq1 = collect(1.0:5.0:42955.0)
 nhanes.seq2 = collect(1.0:9.0:77319.0) # [9k for k in 0:8590.0]
-dnhanes = SurveyDesign!(nhanes; clusters=:SDMVPSU, strata=:SDMVSTRA, weights=:WTMEC2YR)
+dnhanes = SurveyDesign(nhanes; clusters=:SDMVPSU, strata=:SDMVSTRA, weights=:WTMEC2YR)
 dnhanes_boot = dnhanes |> bootweights
 
 @testset "Survey.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,23 +7,23 @@ using DataFrames
 const STAT_TOL = 1e-5
 const SE_TOL = 1e-1
 TOTAL_REPLICATES = 4000
-REPLICATES_VECTOR = [Symbol("replicate_"*string(i)) for i in 1:TOTAL_REPLICATES]
+REPLICATES_VECTOR = [Symbol("replicate_" * string(i)) for i in 1:TOTAL_REPLICATES]
 REPLICATES_REGEX = r"r*_\d"
 
 # Simple random sample
 apisrs = load_data("apisrs") # Load API dataset
-srs = SurveyDesign(apisrs, weights = :pw)
-unitrange = UnitRange((length(names(apisrs)) + 1):(TOTAL_REPLICATES + length(names(apisrs))))
+srs = SurveyDesign!(apisrs, weights=:pw)
+unitrange = UnitRange((length(names(apisrs))+1):(TOTAL_REPLICATES+length(names(apisrs))))
 bsrs = srs |> bootweights # Create bootstrap replicate design
 jsrs = srs |> jackknifeweights # Create jackknife replicate design
-bsrs_direct = ReplicateDesign{BootstrapReplicates}(bsrs.data, REPLICATES_VECTOR, weights = :pw)  # using ReplicateDesign constructor
-bsrs_unitrange = ReplicateDesign{BootstrapReplicates}(bsrs.data, unitrange, weights = :pw)  # using ReplicateDesign constructor
-bsrs_regex = ReplicateDesign{BootstrapReplicates}(bsrs.data, REPLICATES_REGEX, weights = :pw)  # using ReplicateDesign constructor
+bsrs_direct = ReplicateDesign{BootstrapReplicates}(bsrs.data, REPLICATES_VECTOR, weights=:pw)  # using ReplicateDesign constructor
+bsrs_unitrange = ReplicateDesign{BootstrapReplicates}(bsrs.data, unitrange, weights=:pw)  # using ReplicateDesign constructor
+bsrs_regex = ReplicateDesign{BootstrapReplicates}(bsrs.data, REPLICATES_REGEX, weights=:pw)  # using ReplicateDesign constructor
 
 # Stratified sample
 apistrat = load_data("apistrat") # Load API dataset
-dstrat = SurveyDesign(apistrat, strata = :stype, weights = :pw) # Create SurveyDesign
-unitrange = UnitRange((length(names(apistrat)) + 1):(TOTAL_REPLICATES + length(names(apistrat))))
+dstrat = SurveyDesign!(apistrat, strata=:stype, weights=:pw) # Create SurveyDesign
+unitrange = UnitRange((length(names(apistrat))+1):(TOTAL_REPLICATES+length(names(apistrat))))
 bstrat = dstrat |> bootweights # Create replicate design
 bstrat_direct = ReplicateDesign{BootstrapReplicates}(bstrat.data, REPLICATES_VECTOR, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
 bstrat_unitrange = ReplicateDesign{BootstrapReplicates}(bstrat.data, unitrange, strata=:stype, weights=:pw)  # using ReplicateDesign constructor
@@ -32,8 +32,8 @@ bstrat_regex = ReplicateDesign{BootstrapReplicates}(bstrat.data, REPLICATES_REGE
 # One-stage cluster sample
 apiclus1 = load_data("apiclus1") # Load API dataset
 apiclus1[!, :pw] = fill(757 / 15, (size(apiclus1, 1),)) # Correct api mistake for pw column
-dclus1 = SurveyDesign(apiclus1; clusters = :dnum, weights = :pw) # Create SurveyDesign
-unitrange = UnitRange((length(names(apiclus1)) + 1):(TOTAL_REPLICATES + length(names(apiclus1))))
+dclus1 = SurveyDesign!(apiclus1; clusters=:dnum, weights=:pw) # Create SurveyDesign
+unitrange = UnitRange((length(names(apiclus1))+1):(TOTAL_REPLICATES+length(names(apiclus1))))
 dclus1_boot = dclus1 |> bootweights # Create replicate design
 dclus1_boot_direct = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, REPLICATES_VECTOR, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
 dclus1_boot_unitrange = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, unitrange, clusters=:dnum, weights=:pw)  # using ReplicateDesign constructor
@@ -41,14 +41,14 @@ dclus1_boot_regex = ReplicateDesign{BootstrapReplicates}(dclus1_boot.data, REPLI
 
 # Two-stage cluster sample
 apiclus2 = load_data("apiclus2") # Load API dataset
-dclus2 = SurveyDesign(apiclus2; clusters = :dnum, weights = :pw) # Create SurveyDesign
+dclus2 = SurveyDesign!(apiclus2; clusters=:dnum, weights=:pw) # Create SurveyDesign
 dclus2_boot = dclus2 |> bootweights # Create replicate design
 
 # NHANES
 nhanes = load_data("nhanes")
 nhanes.seq1 = collect(1.0:5.0:42955.0)
 nhanes.seq2 = collect(1.0:9.0:77319.0) # [9k for k in 0:8590.0]
-dnhanes = SurveyDesign(nhanes; clusters = :SDMVPSU, strata = :SDMVSTRA, weights = :WTMEC2YR)
+dnhanes = SurveyDesign!(nhanes; clusters=:SDMVPSU, strata=:SDMVSTRA, weights=:WTMEC2YR)
 dnhanes_boot = dnhanes |> bootweights
 
 @testset "Survey.jl" begin


### PR DESCRIPTION
This commit updates the SurveyDesign constructor to SurveyDesign! across multiple files including SurveyDesign.jl, by.jl, and runtests.jl. The change reflects a move towards a more explicit indication of in-place modifications or significant changes that the constructor might perform on the data it receives. This naming convention aligns with Julia's standard practice of using the bang symbol (!) to denote functions that modify their arguments or have important side effects.

Additionally, minor formatting adjustments were made in runtests.jl to improve code readability and consistency with Julia's style guidelines.